### PR TITLE
FLEX-1623 Implement SetTransitionRequest message for Kaifa

### DIFF
--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetTransitionRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetTransitionRequestMessageProcessor.java
@@ -14,9 +14,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
+import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
+import com.alliander.osgp.adapter.protocol.iec61850.device.requests.SetTransitionDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.dto.valueobjects.TransitionMessageDataContainer;
+import com.alliander.osgp.shared.exceptionhandling.ComponentType;
+import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -75,15 +81,49 @@ public class PublicLightingSetTransitionRequestMessageProcessor extends DeviceRe
             final TransitionMessageDataContainer transitionMessageDataContainer = (TransitionMessageDataContainer) message
                     .getObject();
 
+            final RequestMessageData requestMessageData = new RequestMessageData(transitionMessageDataContainer,
+                    domain, domainVersion, messageType, retryCount, isScheduled, correlationUid,
+                    organisationIdentification, deviceIdentification);
+
+            final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
+
+                @Override
+                public void handleResponse(final DeviceResponse deviceResponse) {
+                    PublicLightingSetTransitionRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
+                            PublicLightingSetTransitionRequestMessageProcessor.this.responseMessageSender,
+                            requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
+                            requestMessageData.getMessageType(), requestMessageData.getRetryCount());
+                }
+
+                @Override
+                public void handleException(final Throwable t, final DeviceResponse deviceResponse,
+                        final boolean expected) {
+
+                    if (expected) {
+                        PublicLightingSetTransitionRequestMessageProcessor.this.handleExpectedError(
+                                new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
+                                requestMessageData.getCorrelationUid(),
+                                requestMessageData.getOrganisationIdentification(),
+                                requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
+                                requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
+                    } else {
+                        PublicLightingSetTransitionRequestMessageProcessor.this.handleUnExpectedError(deviceResponse,
+                                t,
+                                requestMessageData.getMessageData(), requestMessageData.getDomain(),
+                                requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
+                                requestMessageData.isScheduled(), requestMessageData.getRetryCount());
+                    }
+                }
+            };
+
             LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
 
-            // final SetTransitionDeviceRequest deviceRequest = new
-            // SetTransitionDeviceRequest(organisationIdentification,
-            // deviceIdentification, correlationUid,
-            // transitionMessageDataContainer, domain, domainVersion,
-            // messageType, ipAddress, retryCount, isScheduled);
-            //
-            // this.deviceService.setTransition(deviceRequest);
+            final SetTransitionDeviceRequest deviceRequest = new SetTransitionDeviceRequest(organisationIdentification,
+                    deviceIdentification, correlationUid, transitionMessageDataContainer, domain, domainVersion,
+                    messageType, ipAddress, retryCount, isScheduled);
+
+            this.deviceService.setTransition(deviceRequest, deviceResponseHandler);
+
         } catch (final Exception e) {
             this.handleError(e, correlationUid, organisationIdentification, deviceIdentification, domain,
                     domainVersion, messageType, retryCount);

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/DeviceService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/DeviceService.java
@@ -12,6 +12,7 @@ import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler
 import com.alliander.osgp.adapter.protocol.iec61850.device.requests.SetConfigurationDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.requests.SetLightDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.requests.SetScheduleDeviceRequest;
+import com.alliander.osgp.adapter.protocol.iec61850.device.requests.SetTransitionDeviceRequest;
 import com.alliander.osgp.dto.valueobjects.DeviceStatus;
 
 public interface DeviceService {
@@ -68,6 +69,5 @@ public interface DeviceService {
 
     void setSchedule(SetScheduleDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
 
-    // void setTransition(DeviceRequest deviceRequest, DeviceResponseHandler
-    // deviceResponseHandler);
+    void setTransition(SetTransitionDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850DeviceService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850DeviceService.java
@@ -1163,7 +1163,7 @@ public class Iec61850DeviceService implements DeviceService {
                 LOGGER.info("device: {}, set ctlVal to {} means {} message", deviceIdentification,
                         controlValueForTransition, controlValueForTransition ? "Evening" : "Morning");
 
-                clientAssociation.setDataValues(ctlVal);
+                clientAssociation.setDataValues(oper);
                 return null;
             }
         };

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/LogicalNodeAttributeDefinitons.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/LogicalNodeAttributeDefinitons.java
@@ -216,6 +216,23 @@ public final class LogicalNodeAttributeDefinitons {
      */
     public static final String PROPERTY_RB_OPER_ATTRIBUTE_CONTROL = "ctlVal";
 
+    /**
+     * Property of CSLC Node, Sensor.
+     */
+    public static final String PROPERTY_SENSOR = ".Sensor";
+
+    /**
+     * Attribute of Property Sensor, used to transition the device between day
+     * and night schedule.
+     */
+    public static final String PROPERTY_SENSOR_ATTRIBUTE_OPER = "Oper";
+
+    /**
+     * Attribute of Property Oper, used to transition the device between day and
+     * night schedule.
+     */
+    public static final String PROPERTY_SENSOR_ATTRIBUTE_CONTROL = "ctlVal";
+
     private LogicalNodeAttributeDefinitons() {
         // Private constructor to prevent instantiation of this class.
     }

--- a/parent-pa-iec61850/pom.xml
+++ b/parent-pa-iec61850/pom.xml
@@ -47,8 +47,8 @@
       <layout>default</layout>
     </snapshotRepository>
     <site>
-      <id>pa-oslp</id>
-      <name>pa-oslp</name>
+      <id>pa-iec61850</id>
+      <name>pa-iec61850</name>
       <!-- URL is passed in as a maven argument: -Dmaven.site.distributionManagement.site.url=file:////the/path/to/deploy/the/site/to -->
       <url>${maven.site.distributionManagement.site.url}</url>
     </site>
@@ -111,11 +111,6 @@
   <dependencyManagement>
     <dependencies>
       <!-- Alliander -->
-      <dependency>
-        <groupId>com.alliander.osgp</groupId>
-        <artifactId>oslp</artifactId>
-        <version>${osgp.version}</version>
-      </dependency>
       <dependency>
         <groupId>com.alliander.osgp</groupId>
         <artifactId>osgp-dto</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
       <layout>default</layout>
     </snapshotRepository>
     <site>
-      <id>pa-oslp</id>
-      <name>pa-oslp</name>
+      <id>pa-iec61850</id>
+      <name>pa-iec61850</name>
       <!-- URL is passed in as a maven argument: -Dmaven.site.distributionManagement.site.url=file:////the/path/to/deploy/the/site/to -->
       <url>${maven.site.distributionManagement.site.url}</url>
     </site>


### PR DESCRIPTION
Implements handling of the SetTransitionRequest message for the Kaifa device.

TransitionType DAY_NIGHT results in the SWDeviceGenericIO/CSLC.Sensor.Oper.ctlVal value being set to true (Evening message), while TransitionType NIGHT_DAY sets the control value to false (Morning message).

The optional time value for the TransitionMessageDataContainer is not handled. If it is present a warning is logged indicating it is ignored.