### PR TITLE
FLEX-2318 ~ Feat improve ioexception handling

### DIFF
--- a/osgp-protocol-adapter-iec61850/pom.xml
+++ b/osgp-protocol-adapter-iec61850/pom.xml
@@ -108,6 +108,12 @@
       <artifactId>spring-ws-support</artifactId>
     </dependency>
 
+    <!-- Spring JMS -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jms</artifactId>
+    </dependency>
+
     <!-- Spring Data -->
     <dependency>
       <groupId>org.springframework.data</groupId>

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/application/config/MessagingConfig.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/application/config/MessagingConfig.java
@@ -15,6 +15,8 @@ import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.pool.PooledConnectionFactory;
 import org.apache.activemq.spring.ActiveMQConnectionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -24,6 +26,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.util.ErrorHandler;
 
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageListener;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceResponseMessageSender;
@@ -39,6 +42,8 @@ import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.OsgpResponse
 @EnableTransactionManagement()
 @PropertySource("file:${osp/osgpAdapterProtocolIec61850/config}")
 public class MessagingConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessagingConfig.class);
 
     // JMS Settings
     private static final String PROPERTY_NAME_JMS_ACTIVEMQ_BROKER_URL = "jms.activemq.broker.url";
@@ -141,9 +146,7 @@ public class MessagingConfig {
         activeMQConnectionFactory.setRedeliveryPolicyMap(this.redeliveryPolicyMap());
         activeMQConnectionFactory.setBrokerURL(this.environment
                 .getRequiredProperty(PROPERTY_NAME_JMS_ACTIVEMQ_BROKER_URL));
-
         activeMQConnectionFactory.setNonBlockingRedelivery(true);
-
         return activeMQConnectionFactory;
     }
 
@@ -220,6 +223,15 @@ public class MessagingConfig {
                 .getRequiredProperty(PROPERTY_NAME_JMS_IEC61850_REQUESTS_MAX_CONCURRENT_CONSUMERS)));
         messageListenerContainer.setMessageListener(this.iec61850RequestsMessageListener);
         messageListenerContainer.setSessionTransacted(true);
+        messageListenerContainer.setErrorHandler(new ErrorHandler() {
+            @Override
+            public void handleError(final Throwable t) {
+                // Implementing ErrorHandler to prevent logging at WARN level
+                // when JMSException is thrown: Execution of JMS message
+                // listener failed, and no ErrorHandler has been set.
+                LOGGER.debug("iec61850RequestsMessageListenerContainer.ErrorHandler.handleError()", t);
+            }
+        });
         return messageListenerContainer;
     }
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/application/config/MessagingConfig.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/application/config/MessagingConfig.java
@@ -8,7 +8,6 @@
 package com.alliander.osgp.adapter.protocol.iec61850.application.config;
 
 import javax.annotation.Resource;
-import javax.jms.MessageListener;
 
 import org.apache.activemq.RedeliveryPolicy;
 import org.apache.activemq.broker.region.policy.RedeliveryPolicyMap;
@@ -26,6 +25,7 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageListener;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceResponseMessageSender;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.Iec61850LogItemRequestMessageSender;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.OsgpRequestMessageSender;
@@ -124,7 +124,7 @@ public class MessagingConfig {
 
     @Autowired
     @Qualifier("iec61850RequestsMessageListener")
-    private MessageListener iec61850RequestsMessageListener;
+    private DeviceRequestMessageListener iec61850RequestsMessageListener;
 
     // === JMS SETTINGS ===
 
@@ -174,7 +174,6 @@ public class MessagingConfig {
                 .getRequiredProperty(PROPERTY_NAME_JMS_DEFAULT_BACK_OFF_MULTIPLIER)));
         redeliveryPolicy.setUseExponentialBackOff(Boolean.parseBoolean(this.environment
                 .getRequiredProperty(PROPERTY_NAME_JMS_DEFAULT_USE_EXPONENTIAL_BACK_OFF)));
-
         return redeliveryPolicy;
     }
 
@@ -183,6 +182,12 @@ public class MessagingConfig {
     @Bean
     public ActiveMQDestination iec61850RequestsQueue() {
         return new ActiveMQQueue(this.environment.getRequiredProperty(PROPERTY_NAME_JMS_IEC61850_REQUESTS_QUEUE));
+    }
+
+    @Bean
+    public int maxRedeliveriesForIec61850Requests() {
+        return Integer.parseInt(this.environment
+                .getRequiredProperty(PROPERTY_NAME_JMS_IEC61850_REQUESTS_MAXIMUM_REDELIVERIES));
     }
 
     @Bean

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/application/services/DeviceRegistrationService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/application/services/DeviceRegistrationService.java
@@ -66,7 +66,7 @@ public class DeviceRegistrationService {
     public void disableRegistration(final String deviceIdentification, final InetAddress ipAddress, final IED ied)
             throws ProtocolAdapterException {
 
-        final DeviceConnection deviceConnection = this.iec61850DeviceConnectionService.connectWithoutConnectionCashing(
+        final DeviceConnection deviceConnection = this.iec61850DeviceConnectionService.connectWithoutConnectionCaching(
                 ipAddress.getHostAddress(), deviceIdentification, ied, LogicalDevice.LIGHTING);
 
         final Function<Void> function = new Function<Void>() {

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/application/services/DeviceRegistrationService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/application/services/DeviceRegistrationService.java
@@ -11,7 +11,6 @@ import java.net.InetAddress;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import org.openmuc.openiec61850.ServerModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,8 +18,6 @@ import org.springframework.stereotype.Service;
 
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.NodeWriteException;
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.ProtocolAdapterException;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850ClientAssociation;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850Connection;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.DeviceConnection;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.Function;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.IED;
@@ -63,66 +60,41 @@ public class DeviceRegistrationService {
      *            The type of IED.
      *
      * @throws ProtocolAdapterException
-     *             In case the connection to the device can not be established.
+     *             In case the connection to the device can not be established
+     *             or the connection breaks during communication.
      */
     public void disableRegistration(final String deviceIdentification, final InetAddress ipAddress, final IED ied)
             throws ProtocolAdapterException {
-        this.iec61850DeviceConnectionService.connect(ipAddress.getHostAddress(), deviceIdentification, ied,
-                LogicalDevice.LIGHTING);
-        final Iec61850ClientAssociation iec61850ClientAssociation = this.iec61850DeviceConnectionService
-                .getIec61850ClientAssociation(deviceIdentification);
-        final ServerModel serverModel = this.iec61850DeviceConnectionService.getServerModel(deviceIdentification);
-        final DeviceConnection deviceConnection = new DeviceConnection(new Iec61850Connection(
-                iec61850ClientAssociation, serverModel), deviceIdentification, ied);
+
+        final DeviceConnection deviceConnection = this.iec61850DeviceConnectionService.connectWithoutConnectionCashing(
+                ipAddress.getHostAddress(), deviceIdentification, ied, LogicalDevice.LIGHTING);
 
         final Function<Void> function = new Function<Void>() {
 
             @Override
             public Void apply() throws Exception {
-                DeviceRegistrationService.this.setLocationInformation(deviceConnection);
                 DeviceRegistrationService.this.disableRegistration(deviceConnection);
+                DeviceRegistrationService.this.setLocationInformation(deviceConnection);
                 if (DeviceRegistrationService.this.isReportingAfterDeviceRegistrationEnabled) {
                     LOGGER.info("Reporting enabled for device: {}", deviceConnection.getDeviceIdentification());
-                    new Iec61850EnableReportingCommand().enableReportingOnDeviceWithoutUsingSequenceNumber(
-                            DeviceRegistrationService.this.iec61850DeviceConnectionService.getIec61850Client(),
-                            deviceConnection);
-                    // Don't disconnect now! The device should be able to send
-                    // reports.
-                    new Timer().schedule(new TimerTask() {
-                        @Override
-                        public void run() {
-                            try {
-                                new Iec61850ClearReportCommand().clearReportOnDevice(deviceConnection);
-                            } catch (final ProtocolAdapterException e) {
-                                LOGGER.error(
-                                        "Unable to clear report for device: "
-                                                + deviceConnection.getDeviceIdentification(), e);
-                            }
-                            DeviceRegistrationService.this.iec61850DeviceConnectionService.disconnect(deviceConnection
-                                    .getDeviceIdentification());
-                        }
-                    }, DeviceRegistrationService.this.delayAfterDeviceRegistration);
+                    DeviceRegistrationService.this.enableReporting(deviceConnection);
                 } else {
                     LOGGER.info("Reporting disabled for device: {}", deviceIdentification);
-                    DeviceRegistrationService.this.iec61850DeviceConnectionService.disconnect(deviceConnection
-                            .getDeviceIdentification());
+                    DeviceRegistrationService.this.iec61850DeviceConnectionService.disconnect(deviceConnection, null);
                 }
                 return null;
             }
         };
 
-        this.iec61850DeviceConnectionService.sendCommandWithRetry(function);
+        this.iec61850DeviceConnectionService.sendCommandWithRetry(function, deviceIdentification);
     }
 
     /**
      * Set the location information for this device. If the osgp_core database
      * contains longitude and latitude information for the given device, those
      * values must be saved to the corresponding data-attributes.
-     *
-     * @throws NodeWriteException
-     *             In case writing of the longitude or latitude fails.
      */
-    protected void setLocationInformation(final DeviceConnection deviceConnection) throws NodeWriteException {
+    protected void setLocationInformation(final DeviceConnection deviceConnection) {
         final Ssld ssld = DeviceRegistrationService.this.ssldDataRepository.findByDeviceIdentification(deviceConnection
                 .getDeviceIdentification());
         if (ssld != null) {
@@ -132,7 +104,13 @@ public class DeviceRegistrationService {
                     deviceConnection.getDeviceIdentification(), longitude, latitude);
 
             if (longitude != null && latitude != null) {
-                new Iec61850SetGpsCoordinatesCommand().setGpsCoordinates(deviceConnection, longitude, latitude);
+                try {
+                    new Iec61850SetGpsCoordinatesCommand().setGpsCoordinates(deviceConnection, longitude, latitude);
+                } catch (final NodeWriteException e) {
+                    LOGGER.error(
+                            "Unable to set location information for device: "
+                                    + deviceConnection.getDeviceIdentification(), e);
+                }
             }
         }
     }
@@ -146,5 +124,33 @@ public class DeviceRegistrationService {
      */
     protected void disableRegistration(final DeviceConnection deviceConnection) throws NodeWriteException {
         new Iec61850DisableRegistrationCommand().disableRegistration(deviceConnection);
+    }
+
+    protected void enableReporting(final DeviceConnection deviceConnection) {
+        try {
+            new Iec61850EnableReportingCommand().enableReportingOnDeviceWithoutUsingSequenceNumber(
+                    DeviceRegistrationService.this.iec61850DeviceConnectionService.getIec61850Client(),
+                    deviceConnection);
+            // Don't disconnect now! The device should be able to send
+            // reports.
+            this.waitClearReportAndDisconnect(deviceConnection);
+        } catch (final NodeWriteException e) {
+            LOGGER.error("Unable to enabele reporting for device: " + deviceConnection.getDeviceIdentification(), e);
+            DeviceRegistrationService.this.iec61850DeviceConnectionService.disconnect(deviceConnection, null);
+        }
+    }
+
+    protected void waitClearReportAndDisconnect(final DeviceConnection deviceConnection) {
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    new Iec61850ClearReportCommand().clearReportOnDevice(deviceConnection);
+                } catch (final NodeWriteException e) {
+                    LOGGER.error("Unable to clear report for device: " + deviceConnection.getDeviceIdentification(), e);
+                }
+                DeviceRegistrationService.this.iec61850DeviceConnectionService.disconnect(deviceConnection, null);
+            }
+        }, DeviceRegistrationService.this.delayAfterDeviceRegistration);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/device/DeviceResponseHandler.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/device/DeviceResponseHandler.java
@@ -7,9 +7,13 @@
  */
 package com.alliander.osgp.adapter.protocol.iec61850.device;
 
+import javax.jms.JMSException;
+
 public interface DeviceResponseHandler {
 
     void handleResponse(DeviceResponse deviceResponse);
+
+    void handleConnectionFailure(Throwable t, DeviceResponse deviceResponse) throws JMSException;
 
     void handleException(Throwable t, DeviceResponse deviceResponse, boolean expected);
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/device/DeviceResponseHandler.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/device/DeviceResponseHandler.java
@@ -15,6 +15,6 @@ public interface DeviceResponseHandler {
 
     void handleConnectionFailure(Throwable t, DeviceResponse deviceResponse) throws JMSException;
 
-    void handleException(Throwable t, DeviceResponse deviceResponse, boolean expected);
+    void handleException(Throwable t, DeviceResponse deviceResponse);
 
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/device/rtu/RtuDeviceService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/device/rtu/RtuDeviceService.java
@@ -7,6 +7,8 @@
  */
 package com.alliander.osgp.adapter.protocol.iec61850.device.rtu;
 
+import javax.jms.JMSException;
+
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceMessageStatus;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.rtu.requests.GetDataDeviceRequest;
@@ -22,7 +24,7 @@ public interface RtuDeviceService {
      * @returns a {@link GetDataDeviceResponse} via the deviceResponseHandler's
      *          callback.
      */
-    void getData(GetDataDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void getData(GetDataDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler) throws JMSException;
 
     /**
      * Writes the {@link SetPointsRequestDto} to the device.
@@ -30,5 +32,6 @@ public interface RtuDeviceService {
      * @returns a {@link DeviceMessageStatus} via the deviceResponseHandler's
      *          callback.
      */
-    void setSetPoints(SetSetPointsDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void setSetPoints(SetSetPointsDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler)
+            throws JMSException;
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/device/ssld/SsldDeviceService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/device/ssld/SsldDeviceService.java
@@ -7,6 +7,8 @@
  */
 package com.alliander.osgp.adapter.protocol.iec61850.device.ssld;
 
+import javax.jms.JMSException;
+
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceMessageStatus;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
@@ -32,7 +34,7 @@ public interface SsldDeviceService {
      * Returns a {@link GetStatusDeviceResponse} via the deviceResponseHandler's
      * callback.
      */
-    void getStatus(DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler);
+    void getStatus(DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler) throws JMSException;
 
     /**
      * Reads the {@link PowerUsageData} from the device.
@@ -41,7 +43,7 @@ public interface SsldDeviceService {
      * deviceResponseHandler's callback.
      */
     void getPowerUsageHistory(GetPowerUsageHistoryDeviceRequest deviceRequest,
-            DeviceResponseHandler deviceResponseHandler);
+            DeviceResponseHandler deviceResponseHandler) throws JMSException;
 
     /**
      * Switches the given light relays on or off, depending on the given
@@ -50,7 +52,7 @@ public interface SsldDeviceService {
      * Returns a {@link DeviceMessageStatus} via the deviceResponseHandler's
      * callback.
      */
-    void setLight(SetLightDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void setLight(SetLightDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler) throws JMSException;
 
     /**
      * Writes all the given {@link Configuration} data to the device. Ignores
@@ -59,7 +61,8 @@ public interface SsldDeviceService {
      * Returns a {@link DeviceMessageStatus} via the deviceResponseHandler's
      * callback.
      */
-    void setConfiguration(SetConfigurationDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void setConfiguration(SetConfigurationDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler)
+            throws JMSException;
 
     /**
      * Reads {@link Configuration} data from the device.
@@ -67,7 +70,7 @@ public interface SsldDeviceService {
      * Returns a {@link GetConfigurationDeviceResponse} via the
      * deviceResponseHandler's callback.
      */
-    void getConfiguration(DeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void getConfiguration(DeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler) throws JMSException;
 
     /**
      * Signals the Device to reboot.
@@ -75,7 +78,7 @@ public interface SsldDeviceService {
      * Returns a {@link DeviceMessageStatus} via the deviceResponseHandler's
      * callback.
      */
-    void setReboot(DeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void setReboot(DeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler) throws JMSException;
 
     /**
      * Runs a self-test by turning all light relays on or off, depending on
@@ -84,7 +87,8 @@ public interface SsldDeviceService {
      * Returns a {@link DeviceMessageStatus} via the deviceResponseHandler's
      * callback.
      */
-    void runSelfTest(DeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler, boolean startOfTest);
+    void runSelfTest(DeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler, boolean startOfTest)
+            throws JMSException;
 
     /**
      * Writes the list {@link Schedule} entries to the device.
@@ -92,7 +96,8 @@ public interface SsldDeviceService {
      * Returns a {@link DeviceMessageStatus} via the deviceResponseHandler's
      * callback.
      */
-    void setSchedule(SetScheduleDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void setSchedule(SetScheduleDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler)
+            throws JMSException;
 
     /**
      * Reads both the version of the functional and the security firmware.
@@ -100,7 +105,8 @@ public interface SsldDeviceService {
      * Returns a {@link GetFirmwareVersionDeviceResponse} via the
      * deviceResponseHandler's callback.
      */
-    void getFirmwareVersion(DeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void getFirmwareVersion(DeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler)
+            throws JMSException;
 
     /**
      * Writes the {@link TransitionType} to the device.
@@ -108,7 +114,8 @@ public interface SsldDeviceService {
      * Returns a {@link DeviceMessageStatus} via the deviceResponseHandler's
      * callback.
      */
-    void setTransition(SetTransitionDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void setTransition(SetTransitionDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler)
+            throws JMSException;
 
     /**
      * Writes the download URL of the new firmware and the time it has to start
@@ -117,7 +124,8 @@ public interface SsldDeviceService {
      * Returns a {@link DeviceMessageStatus} via the deviceResponseHandler's
      * callback.
      */
-    void updateFirmware(UpdateFirmwareDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler);
+    void updateFirmware(UpdateFirmwareDeviceRequest deviceRequest, DeviceResponseHandler deviceResponseHandler)
+            throws JMSException;
 
     /**
      * Writes the download URL of the new SSL certificate and the time it has to
@@ -127,7 +135,7 @@ public interface SsldDeviceService {
      * callback.
      */
     void updateDeviceSslCertification(UpdateDeviceSslCertificationDeviceRequest deviceRequest,
-            DeviceResponseHandler deviceResponseHandler);
+            DeviceResponseHandler deviceResponseHandler) throws JMSException;
 
     /**
      * Writes the {@link EventNotificationTypeDto} list to the device.
@@ -136,6 +144,6 @@ public interface SsldDeviceService {
      * callback.
      */
     void setEventNotifications(SetEventNotificationsDeviceRequest deviceRequest,
-            DeviceResponseHandler deviceResponseHandler);
+            DeviceResponseHandler deviceResponseHandler) throws JMSException;
 
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/domain/valueobjects/DomainInformation.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/domain/valueobjects/DomainInformation.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2014-2016 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.adapter.protocol.iec61850.domain.valueobjects;
+
+public class DomainInformation {
+
+    final String domain;
+    final String domainVersion;
+
+    public DomainInformation(final String domain, final String domainVersion) {
+        this.domain = domain;
+        this.domainVersion = domainVersion;
+    }
+
+    public String getDomain() {
+        return this.domain;
+    }
+
+    public String getDomainVersion() {
+        return this.domainVersion;
+    }
+}

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/BaseMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/BaseMessageProcessor.java
@@ -157,7 +157,7 @@ public abstract class BaseMessageProcessor implements MessageProcessor {
         final ProtocolResponseMessage protocolResponseMessage = new ProtocolResponseMessage.Builder().domain(domain)
                 .domainVersion(domainVersion).deviceMessageMetadata(deviceMessageMetadata)
                 .result(ResponseMessageResultType.NOT_OK).osgpException(ex).retryCount(retryCount)
-                .dataObject(messageData).build();
+                .dataObject(messageData).scheduled(isScheduled).build();
         this.responseMessageSender.send(protocolResponseMessage);
     }
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/BaseMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/BaseMessageProcessor.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2014-2016 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.adapter.protocol.iec61850.infra.messaging;
+
+import java.io.Serializable;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
+import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.EmptyDeviceResponse;
+import com.alliander.osgp.adapter.protocol.iec61850.services.DeviceResponseService;
+import com.alliander.osgp.shared.exceptionhandling.ComponentType;
+import com.alliander.osgp.shared.exceptionhandling.OsgpException;
+import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
+import com.alliander.osgp.shared.infra.jms.DeviceMessageMetadata;
+import com.alliander.osgp.shared.infra.jms.MessageProcessor;
+import com.alliander.osgp.shared.infra.jms.MessageProcessorMap;
+import com.alliander.osgp.shared.infra.jms.ProtocolResponseMessage;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
+
+public abstract class BaseMessageProcessor implements MessageProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseMessageProcessor.class);
+
+    @Autowired
+    protected int maxRedeliveriesForIec61850Requests;
+
+    @Autowired
+    protected DeviceResponseMessageSender responseMessageSender;
+
+    @Autowired
+    protected DeviceResponseService deviceResponseService;
+
+    @Autowired
+    @Qualifier("iec61850DeviceRequestMessageProcessorMap")
+    protected MessageProcessorMap iec61850RequestMessageProcessorMap;
+
+    protected DeviceRequestMessageType deviceRequestMessageType;
+
+    protected int getJmsXdeliveryCount(final Message message) throws JMSException {
+        final int jmsXdeliveryCount = message.getIntProperty("JMSXDeliveryCount");
+        LOGGER.info("jmsXdeliveryCount: {}", jmsXdeliveryCount);
+        return jmsXdeliveryCount;
+    }
+
+    protected void checkForRedelivery(final OsgpException e, final String correlationUid,
+            final String organisationIdentification, final String deviceIdentification, final String domain,
+            final String domainVersion, final String messageType, final int jmsxDeliveryCount) throws JMSException {
+        final int jmsxRedeliveryCount = jmsxDeliveryCount - 1;
+        LOGGER.info("jmsxDeliveryCount: {}, jmsxRedeliveryCount: {}, maxRedeliveriesForIec61850Requests: {}",
+                jmsxDeliveryCount, jmsxRedeliveryCount, this.maxRedeliveriesForIec61850Requests);
+        if (jmsxRedeliveryCount < this.maxRedeliveriesForIec61850Requests) {
+            LOGGER.info(
+                    "Redelivering message with messageType: {}, correlationUid: {}, for device: {} - jmsxRedeliveryCount: {} is less than maxRedeliveriesForIec61850Requests: {}",
+                    messageType, deviceIdentification, correlationUid, jmsxRedeliveryCount,
+                    this.maxRedeliveriesForIec61850Requests);
+            final JMSException jmsException = new JMSException(
+                    e == null ? "checkForRedelivery() unknown error: Throwable t is null" : e.getMessage());
+            throw jmsException;
+        } else {
+            LOGGER.warn(
+                    "All redelivery attempts failed for message with messageType: {}, correlationUid: {}, for device: {}",
+                    messageType, deviceIdentification, correlationUid);
+            this.handleExpectedError(e, correlationUid, organisationIdentification, deviceIdentification, domain,
+                    domainVersion, messageType);
+        }
+    }
+
+    protected void handleEmptyDeviceResponse(final DeviceResponse deviceResponse,
+            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
+            final String messageType, final int retryCount) {
+
+        ResponseMessageResultType result = ResponseMessageResultType.OK;
+        OsgpException ex = null;
+
+        try {
+            final EmptyDeviceResponse response = (EmptyDeviceResponse) deviceResponse;
+            this.deviceResponseService.handleDeviceMessageStatus(response.getStatus());
+        } catch (final OsgpException e) {
+            LOGGER.error("Device Response Exception", e);
+            result = ResponseMessageResultType.NOT_OK;
+            ex = e;
+        }
+
+        final DeviceMessageMetadata deviceMessageMetadata = new DeviceMessageMetadata(
+                deviceResponse.getDeviceIdentification(), deviceResponse.getOrganisationIdentification(),
+                deviceResponse.getCorrelationUid(), messageType, 0);
+        final ProtocolResponseMessage protocolResponseMessage = new ProtocolResponseMessage.Builder().domain(domain)
+                .domainVersion(domainVersion).deviceMessageMetadata(deviceMessageMetadata).result(result)
+                .osgpException(ex).retryCount(retryCount).build();
+        responseMessageSender.send(protocolResponseMessage);
+    }
+
+    public void handleUnExpectedError(final DeviceResponse deviceResponse, final Throwable t,
+            final Serializable messageData, final String domain, final String domainVersion, final String messageType,
+            final boolean isScheduled, final int retryCount) {
+
+        final OsgpException ex = new TechnicalException(ComponentType.PROTOCOL_IEC61850,
+                t == null ? "no exception specified" : t.getMessage());
+
+        final DeviceMessageMetadata deviceMessageMetadata = new DeviceMessageMetadata(
+                deviceResponse.getDeviceIdentification(), deviceResponse.getOrganisationIdentification(),
+                deviceResponse.getCorrelationUid(), messageType, 0);
+        final ProtocolResponseMessage protocolResponseMessage = new ProtocolResponseMessage.Builder().domain(domain)
+                .domainVersion(domainVersion).deviceMessageMetadata(deviceMessageMetadata)
+                .result(ResponseMessageResultType.NOT_OK).osgpException(ex).retryCount(retryCount).build();
+        this.responseMessageSender.send(protocolResponseMessage);
+    }
+
+    protected void handleExpectedError(final OsgpException e, final String correlationUid,
+            final String organisationIdentification, final String deviceIdentification, final String domain,
+            final String domainVersion, final String messageType) {
+        LOGGER.error("Expected error while processing message", e);
+
+        final int retryCount = Integer.MAX_VALUE;
+
+        final DeviceMessageMetadata deviceMessageMetadata = new DeviceMessageMetadata(deviceIdentification,
+                organisationIdentification, correlationUid, messageType, 0);
+        final ProtocolResponseMessage protocolResponseMessage = new ProtocolResponseMessage.Builder().domain(domain)
+                .domainVersion(domainVersion).deviceMessageMetadata(deviceMessageMetadata)
+                .result(ResponseMessageResultType.NOT_OK).osgpException(e).retryCount(retryCount).build();
+        this.responseMessageSender.send(protocolResponseMessage);
+    }
+}

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/DeviceRequestMessageListener.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/DeviceRequestMessageListener.java
@@ -69,11 +69,10 @@ public class DeviceRequestMessageListener implements SessionAwareMessageListener
     }
 
     private void createAndSendException(final ObjectMessage objectMessage, final String messageType) {
-        this.sendException(objectMessage, new NotSupportedException(ComponentType.PROTOCOL_IEC61850, messageType),
-                "Unsupported device function: " + messageType);
+        this.sendException(objectMessage, new NotSupportedException(ComponentType.PROTOCOL_IEC61850, messageType));
     }
 
-    private void sendException(final ObjectMessage objectMessage, final Exception exception, final String errorMessage) {
+    private void sendException(final ObjectMessage objectMessage, final Exception exception) {
         try {
             final String domain = objectMessage.getStringProperty(Constants.DOMAIN);
             final String domainVersion = objectMessage.getStringProperty(Constants.DOMAIN_VERSION);

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/DeviceRequestMessageProcessorMap.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/DeviceRequestMessageProcessorMap.java
@@ -49,8 +49,4 @@ public class DeviceRequestMessageProcessorMap extends BaseMessageProcessorMap {
 
         return messageProcessor;
     }
-
-    public MessageProcessor getOslpEnvelopeProcessor(final DeviceRequestMessageType messageType) {
-        return this.messageProcessors.get(messageType.ordinal());
-    }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/RtuDeviceRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/RtuDeviceRequestMessageProcessor.java
@@ -7,29 +7,11 @@
  */
 package com.alliander.osgp.adapter.protocol.iec61850.infra.messaging;
 
-import java.io.Serializable;
-
 import javax.annotation.PostConstruct;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.rtu.RtuDeviceService;
-import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.EmptyDeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.GetStatusDeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.services.DeviceResponseService;
-import com.alliander.osgp.dto.valueobjects.DeviceStatusDto;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.OsgpException;
-import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
-import com.alliander.osgp.shared.infra.jms.MessageProcessor;
-import com.alliander.osgp.shared.infra.jms.MessageProcessorMap;
-import com.alliander.osgp.shared.infra.jms.ProtocolResponseMessage;
-import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
-import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
 
 /**
  * Base class for MessageProcessor implementations. Each MessageProcessor
@@ -38,26 +20,12 @@ import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
  * construction. The Singleton instance is added to the HashMap of
  * MessageProcessors after dependency injection has completed.
  */
-public abstract class RtuDeviceRequestMessageProcessor implements MessageProcessor {
+public abstract class RtuDeviceRequestMessageProcessor extends BaseMessageProcessor {
 
     protected static final String UNEXPECTED_EXCEPTION = "Unexpected exception while retrieving response message";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RtuDeviceRequestMessageProcessor.class);
-
     @Autowired
     protected RtuDeviceService deviceService;
-
-    @Autowired
-    protected DeviceResponseMessageSender responseMessageSender;
-
-    @Autowired
-    protected DeviceResponseService deviceResponseService;
-
-    @Autowired
-    @Qualifier("iec61850DeviceRequestMessageProcessorMap")
-    protected MessageProcessorMap iec61850RequestMessageProcessorMap;
-
-    protected final DeviceRequestMessageType deviceRequestMessageType;
 
     /**
      * Each MessageProcessor should register it's MessageType at construction.
@@ -80,72 +48,5 @@ public abstract class RtuDeviceRequestMessageProcessor implements MessageProcess
     public void init() {
         this.iec61850RequestMessageProcessorMap.addMessageProcessor(this.deviceRequestMessageType.ordinal(),
                 this.deviceRequestMessageType.name(), this);
-    }
-
-    protected void handleEmptyDeviceResponse(final DeviceResponse deviceResponse,
-            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
-            final String messageType, final int retryCount) {
-
-        ResponseMessageResultType result = ResponseMessageResultType.OK;
-        OsgpException ex = null;
-
-        try {
-            final EmptyDeviceResponse response = (EmptyDeviceResponse) deviceResponse;
-            this.deviceResponseService.handleDeviceMessageStatus(response.getStatus());
-        } catch (final OsgpException e) {
-            LOGGER.error("Device Response Exception", e);
-            result = ResponseMessageResultType.NOT_OK;
-            ex = e;
-        }
-
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, ex, null, retryCount);
-
-        responseMessageSender.send(responseMessage);
-    }
-
-    // this one is here, because it's used in 3 domains
-    protected void handleGetStatusDeviceResponse(final DeviceResponse deviceResponse,
-            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
-            final String messageType, final int retryCount) {
-
-        final ResponseMessageResultType result = ResponseMessageResultType.OK;
-        final OsgpException osgpException = null;
-
-        final GetStatusDeviceResponse response = (GetStatusDeviceResponse) deviceResponse;
-        final DeviceStatusDto status = response.getDeviceStatus();
-
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, osgpException, status, retryCount);
-
-        responseMessageSender.send(responseMessage);
-    }
-
-    public void handleUnExpectedError(final DeviceResponse deviceResponse, final Throwable t,
-            final Serializable messageData, final String domain, final String domainVersion, final String messageType,
-            final boolean isScheduled, final int retryCount) {
-
-        final ResponseMessageResultType result = ResponseMessageResultType.NOT_OK;
-        final OsgpException ex = new TechnicalException(ComponentType.PROTOCOL_IEC61850, t.getMessage());
-
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, ex, messageData, isScheduled, retryCount);
-
-        this.responseMessageSender.send(responseMessage);
-    }
-
-    protected void handleExpectedError(final OsgpException e, final String correlationUid,
-            final String organisationIdentification, final String deviceIdentification, final String domain,
-            final String domainVersion, final String messageType) {
-        LOGGER.error("Expected error while processing message", e);
-
-        final ProtocolResponseMessage protocolResponseMessage = new ProtocolResponseMessage(domain, domainVersion,
-                messageType, correlationUid, organisationIdentification, deviceIdentification,
-                ResponseMessageResultType.NOT_OK, e, null);
-
-        this.responseMessageSender.send(protocolResponseMessage);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/SsldDeviceRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/SsldDeviceRequestMessageProcessor.java
@@ -7,26 +7,15 @@
  */
 package com.alliander.osgp.adapter.protocol.iec61850.infra.messaging;
 
-import java.io.Serializable;
-
 import javax.annotation.PostConstruct;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.SsldDeviceService;
-import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.EmptyDeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.GetStatusDeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.services.DeviceResponseService;
 import com.alliander.osgp.dto.valueobjects.DeviceStatusDto;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.OsgpException;
-import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
-import com.alliander.osgp.shared.infra.jms.MessageProcessor;
-import com.alliander.osgp.shared.infra.jms.MessageProcessorMap;
+import com.alliander.osgp.shared.infra.jms.DeviceMessageMetadata;
 import com.alliander.osgp.shared.infra.jms.ProtocolResponseMessage;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
@@ -38,26 +27,10 @@ import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
  * construction. The Singleton instance is added to the HashMap of
  * MessageProcessors after dependency injection has completed.
  */
-public abstract class SsldDeviceRequestMessageProcessor implements MessageProcessor {
-
-    protected static final String UNEXPECTED_EXCEPTION = "Unexpected exception while retrieving response message";
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(SsldDeviceRequestMessageProcessor.class);
+public abstract class SsldDeviceRequestMessageProcessor extends BaseMessageProcessor {
 
     @Autowired
     protected SsldDeviceService deviceService;
-
-    @Autowired
-    protected DeviceResponseMessageSender responseMessageSender;
-
-    @Autowired
-    protected DeviceResponseService deviceResponseService;
-
-    @Autowired
-    @Qualifier("iec61850DeviceRequestMessageProcessorMap")
-    protected MessageProcessorMap iec61850RequestMessageProcessorMap;
-
-    protected final DeviceRequestMessageType deviceRequestMessageType;
 
     /**
      * Each MessageProcessor should register it's MessageType at construction.
@@ -82,70 +55,21 @@ public abstract class SsldDeviceRequestMessageProcessor implements MessageProces
                 this.deviceRequestMessageType.name(), this);
     }
 
-    protected void handleEmptyDeviceResponse(final DeviceResponse deviceResponse,
-            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
-            final String messageType, final int retryCount) {
-
-        ResponseMessageResultType result = ResponseMessageResultType.OK;
-        OsgpException ex = null;
-
-        try {
-            final EmptyDeviceResponse response = (EmptyDeviceResponse) deviceResponse;
-            this.deviceResponseService.handleDeviceMessageStatus(response.getStatus());
-        } catch (final OsgpException e) {
-            LOGGER.error("Device Response Exception", e);
-            result = ResponseMessageResultType.NOT_OK;
-            ex = e;
-        }
-
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, ex, null, retryCount);
-
-        responseMessageSender.send(responseMessage);
-    }
-
-    // this one is here, because it's used in 3 domains
+    // This function is used in 3 domains.
     protected void handleGetStatusDeviceResponse(final DeviceResponse deviceResponse,
             final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
             final String messageType, final int retryCount) {
 
-        final ResponseMessageResultType result = ResponseMessageResultType.OK;
-        final OsgpException osgpException = null;
-
         final GetStatusDeviceResponse response = (GetStatusDeviceResponse) deviceResponse;
         final DeviceStatusDto status = response.getDeviceStatus();
 
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, osgpException, status, retryCount);
-
-        responseMessageSender.send(responseMessage);
-    }
-
-    public void handleUnExpectedError(final DeviceResponse deviceResponse, final Throwable t,
-            final Serializable messageData, final String domain, final String domainVersion, final String messageType,
-            final boolean isScheduled, final int retryCount) {
-
-        final ResponseMessageResultType result = ResponseMessageResultType.NOT_OK;
-        final OsgpException ex = new TechnicalException(ComponentType.PROTOCOL_IEC61850, t.getMessage());
-
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, ex, messageData, isScheduled, retryCount);
-
-        this.responseMessageSender.send(responseMessage);
-    }
-
-    protected void handleExpectedError(final OsgpException e, final String correlationUid,
-            final String organisationIdentification, final String deviceIdentification, final String domain,
-            final String domainVersion, final String messageType) {
-        LOGGER.error("Expected error while processing message", e);
-
-        final ProtocolResponseMessage protocolResponseMessage = new ProtocolResponseMessage(domain, domainVersion,
-                messageType, correlationUid, organisationIdentification, deviceIdentification,
-                ResponseMessageResultType.NOT_OK, e, null);
-
-        this.responseMessageSender.send(protocolResponseMessage);
+        final DeviceMessageMetadata deviceMessageMetadata = new DeviceMessageMetadata(
+                deviceResponse.getDeviceIdentification(), deviceResponse.getOrganisationIdentification(),
+                deviceResponse.getCorrelationUid(), messageType, 0);
+        final ProtocolResponseMessage protocolResponseMessage = new ProtocolResponseMessage.Builder().domain(domain)
+                .domainVersion(domainVersion).deviceMessageMetadata(deviceMessageMetadata)
+                .result(ResponseMessageResultType.OK).osgpException(null).retryCount(retryCount).dataObject(status)
+                .build();
+        responseMessageSender.send(protocolResponseMessage);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/SsldDeviceRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/SsldDeviceRequestMessageProcessor.java
@@ -9,6 +9,8 @@ package com.alliander.osgp.adapter.protocol.iec61850.infra.messaging;
 
 import javax.annotation.PostConstruct;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
@@ -28,6 +30,8 @@ import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
  * MessageProcessors after dependency injection has completed.
  */
 public abstract class SsldDeviceRequestMessageProcessor extends BaseMessageProcessor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SsldDeviceRequestMessageProcessor.class);
 
     @Autowired
     protected SsldDeviceService deviceService;
@@ -59,6 +63,7 @@ public abstract class SsldDeviceRequestMessageProcessor extends BaseMessageProce
     protected void handleGetStatusDeviceResponse(final DeviceResponse deviceResponse,
             final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
             final String messageType, final int retryCount) {
+        LOGGER.info("Handling getStatusDeviceResponse for device: {}", deviceResponse.getDeviceIdentification());
 
         final GetStatusDeviceResponse response = (GetStatusDeviceResponse) deviceResponse;
         final DeviceStatusDto status = response.getDeviceStatus();

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonGetConfigurationRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonGetConfigurationRequestMessageProcessor.java
@@ -16,17 +16,17 @@ import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.GetConfigurationDeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.ConfigurationDto;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
 import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.Constants;
+import com.alliander.osgp.shared.infra.jms.DeviceMessageMetadata;
 import com.alliander.osgp.shared.infra.jms.ProtocolResponseMessage;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
@@ -85,51 +85,24 @@ public class CommonGetConfigurationRequestMessageProcessor extends SsldDeviceReq
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonGetConfigurationRequestMessageProcessor.this.handleGetConfigurationDeviceResponse(deviceResponse,
-                        CommonGetConfigurationRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    CommonGetConfigurationRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonGetConfigurationRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonGetConfigurationRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                CommonGetConfigurationRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,
                 correlationUid, domain, domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.getConfiguration(deviceRequest, deviceResponseHandler);
+        this.deviceService.getConfiguration(deviceRequest, iec61850DeviceResponseHandler);
+    }
+
+    @Override
+    public void handleDeviceResponse(final DeviceResponse deviceResponse,
+            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
+            final String messageType, final int retryCount) {
+        LOGGER.info("Override for handleDeviceResponse() by CommonGetFirmwareRequestMessageProcessor");
+        this.handleGetConfigurationDeviceResponse(deviceResponse, responseMessageSender, domain, domainVersion,
+                messageType, retryCount);
     }
 
     private void handleGetConfigurationDeviceResponse(final DeviceResponse deviceResponse,
@@ -142,7 +115,6 @@ public class CommonGetConfigurationRequestMessageProcessor extends SsldDeviceReq
 
         try {
             final GetConfigurationDeviceResponse response = (GetConfigurationDeviceResponse) deviceResponse;
-
             configuration = response.getConfiguration();
         } catch (final Exception e) {
             LOGGER.error("Device Response Exception", e);
@@ -151,11 +123,13 @@ public class CommonGetConfigurationRequestMessageProcessor extends SsldDeviceReq
                     "Unexpected exception while retrieving response message", e);
         }
 
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, osgpException, configuration, retryCount);
+        final DeviceMessageMetadata deviceMessageMetaData = new DeviceMessageMetadata(
+                deviceResponse.getDeviceIdentification(), deviceResponse.getOrganisationIdentification(),
+                deviceResponse.getCorrelationUid(), messageType, 0);
+        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage.Builder().domain(domain)
+                .domainVersion(domainVersion).deviceMessageMetadata(deviceMessageMetaData).result(result)
+                .osgpException(osgpException).dataObject(configuration).retryCount(retryCount).build();
 
         responseMessageSender.send(responseMessage);
     }
-
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonGetFirmwareRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonGetFirmwareRequestMessageProcessor.java
@@ -19,17 +19,17 @@ import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.GetFirmwareVersionDeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.FirmwareVersionDto;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
 import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.Constants;
+import com.alliander.osgp.shared.infra.jms.DeviceMessageMetadata;
 import com.alliander.osgp.shared.infra.jms.ProtocolResponseMessage;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
@@ -88,51 +88,24 @@ public class CommonGetFirmwareRequestMessageProcessor extends SsldDeviceRequestM
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonGetFirmwareRequestMessageProcessor.this.handleGetFirmwareVersionDeviceResponse(deviceResponse,
-                        CommonGetFirmwareRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    CommonGetFirmwareRequestMessageProcessor.this.handleExpectedError(new ConnectionFailureException(
-                            ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                            requestMessageData.getOrganisationIdentification(), requestMessageData
-                                    .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                    .getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonGetFirmwareRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonGetFirmwareRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                CommonGetFirmwareRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,
                 correlationUid, domain, domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.getFirmwareVersion(deviceRequest, deviceResponseHandler);
+        this.deviceService.getFirmwareVersion(deviceRequest, iec61850DeviceResponseHandler);
+    }
+
+    @Override
+    public void handleDeviceResponse(final DeviceResponse deviceResponse,
+            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
+            final String messageType, final int retryCount) {
+        LOGGER.info("Override for handleDeviceResponse() by CommonGetFirmwareRequestMessageProcessor");
+        this.handleGetFirmwareVersionDeviceResponse(deviceResponse, responseMessageSender, domain, domainVersion,
+                messageType, retryCount);
     }
 
     private void handleGetFirmwareVersionDeviceResponse(final DeviceResponse deviceResponse,
@@ -140,14 +113,11 @@ public class CommonGetFirmwareRequestMessageProcessor extends SsldDeviceRequestM
             final String messageType, final int retryCount) {
 
         ResponseMessageResultType result = ResponseMessageResultType.OK;
-
         OsgpException osgpException = null;
-
         List<FirmwareVersionDto> firmwareVersions = null;
 
         try {
             firmwareVersions = ((GetFirmwareVersionDeviceResponse) deviceResponse).getFirmwareVersions();
-
         } catch (final Exception e) {
             LOGGER.error("Device Response Exception", e);
             result = ResponseMessageResultType.NOT_OK;
@@ -155,10 +125,13 @@ public class CommonGetFirmwareRequestMessageProcessor extends SsldDeviceRequestM
                     "Unexpected exception while retrieving response message", e);
         }
 
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, osgpException, (Serializable) firmwareVersions,
-                retryCount);
+        final DeviceMessageMetadata deviceMessageMetaData = new DeviceMessageMetadata(
+                deviceResponse.getDeviceIdentification(), deviceResponse.getOrganisationIdentification(),
+                deviceResponse.getCorrelationUid(), messageType, 0);
+        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage.Builder().domain(domain)
+                .domainVersion(domainVersion).deviceMessageMetadata(deviceMessageMetaData).result(result)
+                .osgpException(osgpException).dataObject((Serializable) firmwareVersions).retryCount(retryCount)
+                .build();
 
         responseMessageSender.send(responseMessage);
     }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonGetStatusRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonGetStatusRequestMessageProcessor.java
@@ -16,13 +16,12 @@ import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.shared.infra.jms.Constants;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
 
 /**
  * Class for processing common get status request messages
@@ -78,49 +77,23 @@ public class CommonGetStatusRequestMessageProcessor extends SsldDeviceRequestMes
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonGetStatusRequestMessageProcessor.this.handleGetStatusDeviceResponse(deviceResponse,
-                        CommonGetStatusRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    CommonGetStatusRequestMessageProcessor.this.handleExpectedError(new ConnectionFailureException(
-                            ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                            requestMessageData.getOrganisationIdentification(), requestMessageData
-                            .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                            .getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonGetStatusRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonGetStatusRequestMessageProcessor.this.getJmsXdeliveryCount(message);
-                CommonGetStatusRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,
                 correlationUid, domain, domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.getStatus(deviceRequest, deviceResponseHandler);
+        this.deviceService.getStatus(deviceRequest, iec61850DeviceResponseHandler);
+    }
+
+    @Override
+    public void handleDeviceResponse(final DeviceResponse deviceResponse,
+            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
+            final String messageType, final int retryCount) {
+        LOGGER.info("Override for handleDeviceResponse() by CommonGetStatusRequestMessageProcessor");
+        this.handleGetStatusDeviceResponse(deviceResponse, responseMessageSender, domain, domainVersion, messageType,
+                retryCount);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonRebootRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonRebootRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
@@ -39,7 +39,7 @@ public class CommonRebootRequestMessageProcessor extends SsldDeviceRequestMessag
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
+    public void processMessage(final ObjectMessage message) throws JMSException {
         LOGGER.debug("Processing common reboot request message");
 
         String correlationUid = null;
@@ -104,6 +104,17 @@ public class CommonRebootRequestMessageProcessor extends SsldDeviceRequestMessag
                             requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
                             requestMessageData.isScheduled(), requestMessageData.getRetryCount());
                 }
+            }
+
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = CommonRebootRequestMessageProcessor.this.getJmsXdeliveryCount(message);
+                CommonRebootRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
+                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                        requestMessageData.getOrganisationIdentification(), requestMessageData
+                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
             }
         };
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonRebootRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonRebootRequestMessageProcessor.java
@@ -15,13 +15,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -78,49 +75,14 @@ public class CommonRebootRequestMessageProcessor extends SsldDeviceRequestMessag
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonRebootRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        CommonRebootRequestMessageProcessor.this.responseMessageSender, requestMessageData.getDomain(),
-                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                        requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    CommonRebootRequestMessageProcessor.this.handleExpectedError(new ConnectionFailureException(
-                            ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                            requestMessageData.getOrganisationIdentification(), requestMessageData
-                            .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                            .getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonRebootRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonRebootRequestMessageProcessor.this.getJmsXdeliveryCount(message);
-                CommonRebootRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,
                 correlationUid, domain, domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.setReboot(deviceRequest, deviceResponseHandler);
+        this.deviceService.setReboot(deviceRequest, iec61850DeviceResponseHandler);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonSetConfigurationRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonSetConfigurationRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetConfigurationDeviceRequest;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.dto.valueobjects.ConfigurationDto;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
@@ -40,7 +40,7 @@ public class CommonSetConfigurationRequestMessageProcessor extends SsldDeviceReq
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
+    public void processMessage(final ObjectMessage message) throws JMSException {
         LOGGER.debug("Processing common set configuration message");
 
         String correlationUid = null;
@@ -107,6 +107,18 @@ public class CommonSetConfigurationRequestMessageProcessor extends SsldDeviceReq
                             requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
                             requestMessageData.isScheduled(), requestMessageData.getRetryCount());
                 }
+            }
+
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = CommonSetConfigurationRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                CommonSetConfigurationRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
+                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                        requestMessageData.getOrganisationIdentification(), requestMessageData
+                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
             }
 
         };

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonSetConfigurationRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonSetConfigurationRequestMessageProcessor.java
@@ -14,15 +14,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetConfigurationDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.ConfigurationDto;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -65,7 +62,6 @@ public class CommonSetConfigurationRequestMessageProcessor extends SsldDeviceReq
             isScheduled = message.getBooleanProperty(Constants.IS_SCHEDULED);
             retryCount = message.getIntProperty(Constants.RETRY_COUNT);
             configuration = (ConfigurationDto) message.getObject();
-
         } catch (final JMSException e) {
             LOGGER.error("UNRECOVERABLE ERROR, unable to read ObjectMessage instance, giving up.", e);
             LOGGER.debug("correlationUid: {}", correlationUid);
@@ -81,54 +77,15 @@ public class CommonSetConfigurationRequestMessageProcessor extends SsldDeviceReq
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonSetConfigurationRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        CommonSetConfigurationRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    CommonSetConfigurationRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonSetConfigurationRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonSetConfigurationRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                CommonSetConfigurationRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final SetConfigurationDeviceRequest deviceRequest = new SetConfigurationDeviceRequest(
                 organisationIdentification, deviceIdentification, correlationUid, configuration, domain, domainVersion,
                 messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.setConfiguration(deviceRequest, deviceResponseHandler);
-
+        this.deviceService.setConfiguration(deviceRequest, iec61850DeviceResponseHandler);
     }
-
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonSetEventNotificationsRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonSetEventNotificationsRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetEventNotificationsDeviceRequest;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.dto.valueobjects.EventNotificationMessageDataContainerDto;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
@@ -41,7 +41,7 @@ public class CommonSetEventNotificationsRequestMessageProcessor extends SsldDevi
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
+    public void processMessage(final ObjectMessage message) throws JMSException {
         LOGGER.debug("Processing common set event notifications request message");
 
         String correlationUid = null;
@@ -107,6 +107,18 @@ public class CommonSetEventNotificationsRequestMessageProcessor extends SsldDevi
                             requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
                             requestMessageData.isScheduled(), requestMessageData.getRetryCount());
                 }
+            }
+
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = CommonSetEventNotificationsRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                CommonSetEventNotificationsRequestMessageProcessor.this.checkForRedelivery(
+                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
+                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
+                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
+                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
             }
 
         };

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonSetEventNotificationsRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonSetEventNotificationsRequestMessageProcessor.java
@@ -14,15 +14,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetEventNotificationsDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.EventNotificationMessageDataContainerDto;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -81,52 +78,15 @@ public class CommonSetEventNotificationsRequestMessageProcessor extends SsldDevi
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonSetEventNotificationsRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        CommonSetEventNotificationsRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    CommonSetEventNotificationsRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonSetEventNotificationsRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonSetEventNotificationsRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                CommonSetEventNotificationsRequestMessageProcessor.this.checkForRedelivery(
-                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final SetEventNotificationsDeviceRequest deviceRequest = new SetEventNotificationsDeviceRequest(
                 organisationIdentification, deviceIdentification, correlationUid, eventNotificationsContainer, domain,
                 domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.setEventNotifications(deviceRequest, deviceResponseHandler);
+        this.deviceService.setEventNotifications(deviceRequest, iec61850DeviceResponseHandler);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonStartDeviceTestRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonStartDeviceTestRequestMessageProcessor.java
@@ -15,13 +15,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -78,52 +75,15 @@ public class CommonStartDeviceTestRequestMessageProcessor extends SsldDeviceRequ
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonStartDeviceTestRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        CommonStartDeviceTestRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-
-                if (expected) {
-                    CommonStartDeviceTestRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonStartDeviceTestRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonStartDeviceTestRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                CommonStartDeviceTestRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
-
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,
                 correlationUid, domain, domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        // This is a start selftest, so startOfTest == true
-        this.deviceService.runSelfTest(deviceRequest, deviceResponseHandler, true);
+        // This is a start self-test, so startOfTest == true.
+        this.deviceService.runSelfTest(deviceRequest, iec61850DeviceResponseHandler, true);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonStartDeviceTestRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonStartDeviceTestRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
@@ -39,7 +39,7 @@ public class CommonStartDeviceTestRequestMessageProcessor extends SsldDeviceRequ
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
+    public void processMessage(final ObjectMessage message) throws JMSException {
         LOGGER.debug("Processing common start device test request message");
 
         String correlationUid = null;
@@ -103,6 +103,18 @@ public class CommonStartDeviceTestRequestMessageProcessor extends SsldDeviceRequ
                             requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
                             requestMessageData.isScheduled(), requestMessageData.getRetryCount());
                 }
+            }
+
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = CommonStartDeviceTestRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                CommonStartDeviceTestRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
+                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                        requestMessageData.getOrganisationIdentification(), requestMessageData
+                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
             }
         };
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonStopDeviceTestRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonStopDeviceTestRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
@@ -105,6 +105,18 @@ public class CommonStopDeviceTestRequestMessageProcessor extends SsldDeviceReque
                             requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
                             requestMessageData.isScheduled(), requestMessageData.getRetryCount());
                 }
+            }
+
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = CommonStopDeviceTestRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                CommonStopDeviceTestRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
+                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                        requestMessageData.getOrganisationIdentification(), requestMessageData
+                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
             }
         };
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonStopDeviceTestRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonStopDeviceTestRequestMessageProcessor.java
@@ -15,13 +15,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -75,57 +72,18 @@ public class CommonStopDeviceTestRequestMessageProcessor extends SsldDeviceReque
             return;
         }
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
-
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonStopDeviceTestRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        CommonStopDeviceTestRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-
-                if (expected) {
-                    CommonStopDeviceTestRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonStopDeviceTestRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonStopDeviceTestRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                CommonStopDeviceTestRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
-
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,
                 correlationUid, domain, domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        // This is a stop selftest, so startOfTest == false
-        this.deviceService.runSelfTest(deviceRequest, deviceResponseHandler, false);
+        // This is a stop self-test, so startOfTest == false.
+        this.deviceService.runSelfTest(deviceRequest, iec61850DeviceResponseHandler, false);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonUpdateDeviceSslCertificationRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonUpdateDeviceSslCertificationRequestMessageProcessor.java
@@ -14,15 +14,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.UpdateDeviceSslCertificationDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.CertificationDto;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -82,54 +79,15 @@ public class CommonUpdateDeviceSslCertificationRequestMessageProcessor extends S
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonUpdateDeviceSslCertificationRequestMessageProcessor.this.handleEmptyDeviceResponse(
-                        deviceResponse,
-                        CommonUpdateDeviceSslCertificationRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    CommonUpdateDeviceSslCertificationRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonUpdateDeviceSslCertificationRequestMessageProcessor.this.handleUnExpectedError(
-                            deviceResponse, t, requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonUpdateDeviceSslCertificationRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                CommonUpdateDeviceSslCertificationRequestMessageProcessor.this.checkForRedelivery(
-                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final UpdateDeviceSslCertificationDeviceRequest deviceRequest = new UpdateDeviceSslCertificationDeviceRequest(
                 organisationIdentification, deviceIdentification, correlationUid, certification, domain, domainVersion,
                 messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.updateDeviceSslCertification(deviceRequest, deviceResponseHandler);
-
+        this.deviceService.updateDeviceSslCertification(deviceRequest, iec61850DeviceResponseHandler);
     }
-
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonUpdateFirmwareRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonUpdateFirmwareRequestMessageProcessor.java
@@ -19,8 +19,8 @@ import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.FirmwareLocation;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.UpdateFirmwareDeviceRequest;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
@@ -44,7 +44,7 @@ public class CommonUpdateFirmwareRequestMessageProcessor extends SsldDeviceReque
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
+    public void processMessage(final ObjectMessage message) throws JMSException {
         LOGGER.debug("Processing common update firmware request message");
 
         String correlationUid = null;
@@ -111,6 +111,18 @@ public class CommonUpdateFirmwareRequestMessageProcessor extends SsldDeviceReque
                             requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
                             requestMessageData.isScheduled(), requestMessageData.getRetryCount());
                 }
+            }
+
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = CommonUpdateFirmwareRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                CommonUpdateFirmwareRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
+                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                        requestMessageData.getOrganisationIdentification(), requestMessageData
+                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
             }
 
         };

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonUpdateFirmwareRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/CommonUpdateFirmwareRequestMessageProcessor.java
@@ -15,15 +15,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.FirmwareLocation;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.UpdateFirmwareDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -85,53 +82,16 @@ public class CommonUpdateFirmwareRequestMessageProcessor extends SsldDeviceReque
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                CommonUpdateFirmwareRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        CommonUpdateFirmwareRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    CommonUpdateFirmwareRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    CommonUpdateFirmwareRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = CommonUpdateFirmwareRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                CommonUpdateFirmwareRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final UpdateFirmwareDeviceRequest deviceRequest = new UpdateFirmwareDeviceRequest(organisationIdentification,
                 deviceIdentification, correlationUid, this.firmwareLocation.getDomain(),
                 this.firmwareLocation.getFullPath(firmwareIdentification), domain, domainVersion, messageType,
                 ipAddress, retryCount, isScheduled);
 
-        this.deviceService.updateFirmware(deviceRequest, deviceResponseHandler);
+        this.deviceService.updateFirmware(deviceRequest, iec61850DeviceResponseHandler);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/MicrogridsGetDataRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/MicrogridsGetDataRequestMessageProcessor.java
@@ -47,8 +47,8 @@ public class MicrogridsGetDataRequestMessageProcessor extends RtuDeviceRequestMe
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
-        LOGGER.info("Processing microgrids get data request message");
+    public void processMessage(final ObjectMessage message) throws JMSException {
+        LOGGER.debug("Processing microgrids get data request message");
 
         String correlationUid = null;
         String domain = null;
@@ -70,9 +70,9 @@ public class MicrogridsGetDataRequestMessageProcessor extends RtuDeviceRequestMe
             deviceIdentification = message.getStringProperty(Constants.DEVICE_IDENTIFICATION);
             ipAddress = message.getStringProperty(Constants.IP_ADDRESS);
             retryCount = message.getIntProperty(Constants.RETRY_COUNT);
-            isScheduled = message.propertyExists(Constants.IS_SCHEDULED)
-                    ? message.getBooleanProperty(Constants.IS_SCHEDULED) : false;
-            getDataRequest = (DataRequestDto) message.getObject();
+            isScheduled = message.propertyExists(Constants.IS_SCHEDULED) ? message
+                    .getBooleanProperty(Constants.IS_SCHEDULED) : false;
+                    getDataRequest = (DataRequestDto) message.getObject();
         } catch (final JMSException e) {
             LOGGER.error("UNRECOVERABLE ERROR, unable to read ObjectMessage instance, giving up.", e);
             LOGGER.debug("correlationUid: {}", correlationUid);
@@ -101,14 +101,13 @@ public class MicrogridsGetDataRequestMessageProcessor extends RtuDeviceRequestMe
             }
 
             @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse,
-                    final boolean expected) {
+            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
                 if (expected) {
-                    MicrogridsGetDataRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
+                    MicrogridsGetDataRequestMessageProcessor.this.handleExpectedError(new ConnectionFailureException(
+                            ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                            requestMessageData.getOrganisationIdentification(), requestMessageData
+                                    .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                                    .getDomainVersion(), requestMessageData.getMessageType());
                 } else {
                     MicrogridsGetDataRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
                             requestMessageData.getMessageData(), requestMessageData.getDomain(),
@@ -117,6 +116,17 @@ public class MicrogridsGetDataRequestMessageProcessor extends RtuDeviceRequestMe
                 }
             }
 
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = MicrogridsGetDataRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                MicrogridsGetDataRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
+                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                        requestMessageData.getOrganisationIdentification(), requestMessageData
+                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
+            }
         };
 
         final GetDataDeviceRequest deviceRequest = new GetDataDeviceRequest(organisationIdentification,
@@ -151,5 +161,4 @@ public class MicrogridsGetDataRequestMessageProcessor extends RtuDeviceRequestMe
 
         responseMessageSender.send(responseMessage);
     }
-
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/MicrogridsGetDataRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/MicrogridsGetDataRequestMessageProcessor.java
@@ -15,19 +15,19 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.rtu.requests.GetDataDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.GetDataDeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.RtuDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.microgrids.DataRequestDto;
 import com.alliander.osgp.dto.valueobjects.microgrids.DataResponseDto;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
 import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.Constants;
+import com.alliander.osgp.shared.infra.jms.DeviceMessageMetadata;
 import com.alliander.osgp.shared.infra.jms.ProtocolResponseMessage;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
@@ -88,52 +88,25 @@ public class MicrogridsGetDataRequestMessageProcessor extends RtuDeviceRequestMe
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                MicrogridsGetDataRequestMessageProcessor.this.handleGetDataDeviceResponse(deviceResponse,
-                        MicrogridsGetDataRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    MicrogridsGetDataRequestMessageProcessor.this.handleExpectedError(new ConnectionFailureException(
-                            ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                            requestMessageData.getOrganisationIdentification(), requestMessageData
-                                    .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                    .getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    MicrogridsGetDataRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = MicrogridsGetDataRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                MicrogridsGetDataRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                                .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                                .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final GetDataDeviceRequest deviceRequest = new GetDataDeviceRequest(organisationIdentification,
                 deviceIdentification, correlationUid, getDataRequest, domain, domainVersion, messageType, ipAddress,
                 retryCount, isScheduled);
 
-        this.deviceService.getData(deviceRequest, deviceResponseHandler);
+        this.deviceService.getData(deviceRequest, iec61850DeviceResponseHandler);
+    }
+
+    @Override
+    public void handleDeviceResponse(final DeviceResponse deviceResponse,
+            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
+            final String messageType, final int retryCount) {
+        LOGGER.info("Override for handleDeviceResponse() by MicrogridsGetDataRequestMessageProcessor");
+        this.handleGetDataDeviceResponse(deviceResponse, responseMessageSender, domain, domainVersion, messageType,
+                retryCount);
     }
 
     private void handleGetDataDeviceResponse(final DeviceResponse deviceResponse,
@@ -146,7 +119,6 @@ public class MicrogridsGetDataRequestMessageProcessor extends RtuDeviceRequestMe
 
         try {
             final GetDataDeviceResponse response = (GetDataDeviceResponse) deviceResponse;
-
             dataResponse = response.getDataResponse();
         } catch (final Exception e) {
             LOGGER.error("Device Response Exception", e);
@@ -155,9 +127,12 @@ public class MicrogridsGetDataRequestMessageProcessor extends RtuDeviceRequestMe
                     "Unexpected exception while retrieving response message", e);
         }
 
-        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage(domain, domainVersion, messageType,
-                deviceResponse.getCorrelationUid(), deviceResponse.getOrganisationIdentification(),
-                deviceResponse.getDeviceIdentification(), result, osgpException, dataResponse, retryCount);
+        final DeviceMessageMetadata deviceMessageMetaData = new DeviceMessageMetadata(
+                deviceResponse.getDeviceIdentification(), deviceResponse.getOrganisationIdentification(),
+                deviceResponse.getCorrelationUid(), messageType, 0);
+        final ProtocolResponseMessage responseMessage = new ProtocolResponseMessage.Builder().domain(domain)
+                .domainVersion(domainVersion).deviceMessageMetadata(deviceMessageMetaData).result(result)
+                .osgpException(osgpException).dataObject(dataResponse).retryCount(retryCount).build();
 
         responseMessageSender.send(responseMessage);
     }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingGetPowerUsageHistoryRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingGetPowerUsageHistoryRequestMessageProcessor.java
@@ -15,23 +15,22 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.GetPowerUsageHistoryDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.responses.GetPowerUsageHistoryDeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceResponseMessageSender;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.PowerUsageHistoryMessageDataContainerDto;
 import com.alliander.osgp.dto.valueobjects.PowerUsageHistoryResponseMessageDataContainerDto;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.exceptionhandling.OsgpException;
 import com.alliander.osgp.shared.exceptionhandling.TechnicalException;
 import com.alliander.osgp.shared.infra.jms.Constants;
 import com.alliander.osgp.shared.infra.jms.DeviceMessageMetadata;
 import com.alliander.osgp.shared.infra.jms.ProtocolResponseMessage;
 import com.alliander.osgp.shared.infra.jms.ResponseMessageResultType;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
 
 /**
  * Class for processing public lighting get power usage history request messages
@@ -61,8 +60,8 @@ public class PublicLightingGetPowerUsageHistoryRequestMessageProcessor extends S
         String ipAddress = null;
         Boolean isScheduled = null;
         int retryCount = 0;
-        final int messagePriority;
-        final Long scheduleTime;
+        int messagePriority = 0;
+        Long scheduleTime = null;
         PowerUsageHistoryMessageDataContainerDto powerUsageHistoryMessageDataContainerDto;
 
         try {
@@ -78,8 +77,7 @@ public class PublicLightingGetPowerUsageHistoryRequestMessageProcessor extends S
             messagePriority = message.getJMSPriority();
             scheduleTime = message.propertyExists(Constants.SCHEDULE_TIME) ? message
                     .getLongProperty(Constants.SCHEDULE_TIME) : null;
-                    powerUsageHistoryMessageDataContainerDto = (PowerUsageHistoryMessageDataContainerDto) message.getObject();
-
+            powerUsageHistoryMessageDataContainerDto = (PowerUsageHistoryMessageDataContainerDto) message.getObject();
         } catch (final JMSException e) {
             LOGGER.error("UNRECOVERABLE ERROR, unable to read ObjectMessage instance, giving up.", e);
             LOGGER.debug("correlationUid: {}", correlationUid);
@@ -90,76 +88,50 @@ public class PublicLightingGetPowerUsageHistoryRequestMessageProcessor extends S
             LOGGER.debug("deviceIdentification: {}", deviceIdentification);
             LOGGER.debug("ipAddress: {}", ipAddress);
             LOGGER.debug("scheduled: {}", isScheduled);
+            LOGGER.debug("retryCount: {}", retryCount);
+            LOGGER.debug("messagePriority: {}", messagePriority);
+            LOGGER.debug("scheduleTime: {}", scheduleTime);
             return;
         }
 
         final RequestMessageData requestMessageData = new RequestMessageData(powerUsageHistoryMessageDataContainerDto,
                 domain, domainVersion, messageType, retryCount, isScheduled, correlationUid,
-                organisationIdentification, deviceIdentification);
+                organisationIdentification, deviceIdentification, ipAddress, messagePriority, scheduleTime);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                PublicLightingGetPowerUsageHistoryRequestMessageProcessor.this
-                .handleGetPowerUsageHistoryDeviceResponse((GetPowerUsageHistoryDeviceResponse) deviceResponse,
-                        PublicLightingGetPowerUsageHistoryRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount(),
-                        messagePriority, scheduleTime);
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-
-                if (expected) {
-                    PublicLightingGetPowerUsageHistoryRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    PublicLightingGetPowerUsageHistoryRequestMessageProcessor.this.handleUnExpectedError(
-                            deviceResponse, t, requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = PublicLightingGetPowerUsageHistoryRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                PublicLightingGetPowerUsageHistoryRequestMessageProcessor.this.checkForRedelivery(
-                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
-
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final GetPowerUsageHistoryDeviceRequest deviceRequest = new GetPowerUsageHistoryDeviceRequest(
                 organisationIdentification, deviceIdentification, correlationUid,
                 powerUsageHistoryMessageDataContainerDto, domain, domainVersion, messageType, ipAddress, retryCount,
                 isScheduled);
 
-        this.deviceService.getPowerUsageHistory(deviceRequest, deviceResponseHandler);
+        this.deviceService.getPowerUsageHistory(deviceRequest, iec61850DeviceResponseHandler);
     }
 
-    private void handleGetPowerUsageHistoryDeviceResponse(final GetPowerUsageHistoryDeviceResponse deviceResponse,
-            final DeviceResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
+    @Override
+    public void handleDeviceResponse(final DeviceResponse deviceResponse,
+            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
+            final String messageType, final int retryCount, final int messagePriority, final Long scheduleTime) {
+        LOGGER.info("Override for handleDeviceResponse() by PublicLightingGetPowerUsageHistoryRequestMessageProcessor");
+        this.handleGetPowerUsageHistoryDeviceResponse(deviceResponse, responseMessageSender, domain, domainVersion,
+                messageType, retryCount, messagePriority, scheduleTime);
+    }
+
+    private void handleGetPowerUsageHistoryDeviceResponse(final DeviceResponse deviceResponse,
+            final ResponseMessageSender responseMessageSender, final String domain, final String domainVersion,
             final String messageType, final int retryCount, final int messagePriority, final Long scheduleTime) {
 
+        final GetPowerUsageHistoryDeviceResponse getPowerUsageHistoryDeviceResponse = (GetPowerUsageHistoryDeviceResponse) deviceResponse;
         ResponseMessageResultType result = ResponseMessageResultType.OK;
         OsgpException osgpException = null;
         PowerUsageHistoryResponseMessageDataContainerDto powerUsageHistoryResponseMessageDataContainer = null;
 
         try {
             powerUsageHistoryResponseMessageDataContainer = new PowerUsageHistoryResponseMessageDataContainerDto(
-                    deviceResponse.getPowerUsageHistoryData());
+                    getPowerUsageHistoryDeviceResponse.getPowerUsageHistoryData());
         } catch (final Exception e) {
             LOGGER.error("Device Response Exception", e);
             result = ResponseMessageResultType.NOT_OK;
@@ -177,5 +149,4 @@ public class PublicLightingGetPowerUsageHistoryRequestMessageProcessor extends S
 
         responseMessageSender.send(responseMessage);
     }
-
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingGetStatusRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingGetStatusRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
@@ -39,8 +39,8 @@ public class PublicLightingGetStatusRequestMessageProcessor extends SsldDeviceRe
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
-        LOGGER.info("Processing public lighting get status request message");
+    public void processMessage(final ObjectMessage message) throws JMSException {
+        LOGGER.debug("Processing public lighting get status request message");
 
         String correlationUid = null;
         String domain = null;
@@ -106,6 +106,17 @@ public class PublicLightingGetStatusRequestMessageProcessor extends SsldDeviceRe
                 }
             }
 
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = PublicLightingGetStatusRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                PublicLightingGetStatusRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
+                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                        requestMessageData.getOrganisationIdentification(), requestMessageData
+                        .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                        .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
+            }
         };
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingGetStatusRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingGetStatusRequestMessageProcessor.java
@@ -16,12 +16,10 @@ import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -78,51 +76,23 @@ public class PublicLightingGetStatusRequestMessageProcessor extends SsldDeviceRe
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                PublicLightingGetStatusRequestMessageProcessor.this.handleGetStatusDeviceResponse(deviceResponse,
-                        PublicLightingGetStatusRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    PublicLightingGetStatusRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    PublicLightingGetStatusRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = PublicLightingGetStatusRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                PublicLightingGetStatusRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                        .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                        .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,
                 correlationUid, domain, domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.getStatus(deviceRequest, deviceResponseHandler);
+        this.deviceService.getStatus(deviceRequest, iec61850DeviceResponseHandler);
     }
 
+    @Override
+    public void handleDeviceResponse(final DeviceResponse deviceResponse,
+            final com.alliander.osgp.shared.infra.jms.ResponseMessageSender responseMessageSender, final String domain,
+            final String domainVersion, final String messageType, final int retryCount) {
+        LOGGER.info("Override for handleDeviceResponse() by PublicLightingGetStatusRequestMessageProcessor");
+        this.handleGetStatusDeviceResponse(deviceResponse, responseMessageSender, domain, domainVersion, messageType,
+                retryCount);
+    }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetScheduleRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetScheduleRequestMessageProcessor.java
@@ -14,16 +14,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetScheduleDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.RelayTypeDto;
 import com.alliander.osgp.dto.valueobjects.ScheduleMessageDataContainerDto;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -85,52 +82,15 @@ public class PublicLightingSetScheduleRequestMessageProcessor extends SsldDevice
                 domainVersion, messageType, retryCount, isScheduled, correlationUid, organisationIdentification,
                 deviceIdentification);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                PublicLightingSetScheduleRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        PublicLightingSetScheduleRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-
-                if (expected) {
-                    PublicLightingSetScheduleRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    PublicLightingSetScheduleRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = PublicLightingSetScheduleRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                PublicLightingSetScheduleRequestMessageProcessor.this.checkForRedelivery(
-                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
-
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final SetScheduleDeviceRequest deviceRequest = new SetScheduleDeviceRequest(organisationIdentification,
                 deviceIdentification, correlationUid, scheduleMessageDataContainer, RelayTypeDto.LIGHT, domain,
                 domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.setSchedule(deviceRequest, deviceResponseHandler);
+        this.deviceService.setSchedule(deviceRequest, iec61850DeviceResponseHandler);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetScheduleRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetScheduleRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetScheduleDeviceRequest;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.dto.valueobjects.RelayTypeDto;
 import com.alliander.osgp.dto.valueobjects.ScheduleMessageDataContainerDto;
@@ -42,7 +42,7 @@ public class PublicLightingSetScheduleRequestMessageProcessor extends SsldDevice
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
+    public void processMessage(final ObjectMessage message) throws JMSException {
         LOGGER.debug("Processing public lighting set schedule request message");
 
         String correlationUid = null;
@@ -111,6 +111,18 @@ public class PublicLightingSetScheduleRequestMessageProcessor extends SsldDevice
                             requestMessageData.isScheduled(), requestMessageData.getRetryCount());
                 }
             }
+
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = PublicLightingSetScheduleRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                PublicLightingSetScheduleRequestMessageProcessor.this.checkForRedelivery(
+                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
+                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
+                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
+                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
+            }
         };
 
         LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
@@ -121,5 +133,4 @@ public class PublicLightingSetScheduleRequestMessageProcessor extends SsldDevice
 
         this.deviceService.setSchedule(deviceRequest, deviceResponseHandler);
     }
-
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetTransitionRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetTransitionRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetTransitionDeviceRequest;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.dto.valueobjects.TransitionMessageDataContainerDto;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
@@ -41,7 +41,7 @@ public class PublicLightingSetTransitionRequestMessageProcessor extends SsldDevi
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
+    public void processMessage(final ObjectMessage message) throws JMSException {
         LOGGER.debug("Processing public lighting set transition request message");
 
         String correlationUid = null;
@@ -108,6 +108,18 @@ public class PublicLightingSetTransitionRequestMessageProcessor extends SsldDevi
                             requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
                             requestMessageData.isScheduled(), requestMessageData.getRetryCount());
                 }
+            }
+
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = PublicLightingSetTransitionRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                PublicLightingSetTransitionRequestMessageProcessor.this.checkForRedelivery(
+                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
+                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
+                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
+                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
             }
         };
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetTransitionRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/PublicLightingSetTransitionRequestMessageProcessor.java
@@ -14,15 +14,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetTransitionDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.TransitionMessageDataContainerDto;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -83,52 +80,15 @@ public class PublicLightingSetTransitionRequestMessageProcessor extends SsldDevi
                 domainVersion, messageType, retryCount, isScheduled, correlationUid, organisationIdentification,
                 deviceIdentification);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                PublicLightingSetTransitionRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        PublicLightingSetTransitionRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-
-                if (expected) {
-                    PublicLightingSetTransitionRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    PublicLightingSetTransitionRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = PublicLightingSetTransitionRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                PublicLightingSetTransitionRequestMessageProcessor.this.checkForRedelivery(
-                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
-
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final SetTransitionDeviceRequest deviceRequest = new SetTransitionDeviceRequest(organisationIdentification,
                 deviceIdentification, correlationUid, transitionMessageDataContainer, domain, domainVersion,
                 messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.setTransition(deviceRequest, deviceResponseHandler);
+        this.deviceService.setTransition(deviceRequest, iec61850DeviceResponseHandler);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/TariffSwitchingGetStatusRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/TariffSwitchingGetStatusRequestMessageProcessor.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
 import com.alliander.osgp.shared.exceptionhandling.ComponentType;
 import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
@@ -39,8 +39,8 @@ public class TariffSwitchingGetStatusRequestMessageProcessor extends SsldDeviceR
     }
 
     @Override
-    public void processMessage(final ObjectMessage message) {
-        LOGGER.info("Processing tariff switching get status request message");
+    public void processMessage(final ObjectMessage message) throws JMSException {
+        LOGGER.debug("Processing tariff switching get status request message");
 
         String correlationUid = null;
         String domain = null;
@@ -106,6 +106,17 @@ public class TariffSwitchingGetStatusRequestMessageProcessor extends SsldDeviceR
                 }
             }
 
+            @Override
+            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
+                    throws JMSException {
+                final int jmsxDeliveryCount = TariffSwitchingGetStatusRequestMessageProcessor.this
+                        .getJmsXdeliveryCount(message);
+                TariffSwitchingGetStatusRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
+                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
+                        requestMessageData.getOrganisationIdentification(), requestMessageData
+                        .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
+                        .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
+            }
         };
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/TariffSwitchingGetStatusRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/TariffSwitchingGetStatusRequestMessageProcessor.java
@@ -16,12 +16,10 @@ import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -78,50 +76,23 @@ public class TariffSwitchingGetStatusRequestMessageProcessor extends SsldDeviceR
         final RequestMessageData requestMessageData = new RequestMessageData(null, domain, domainVersion, messageType,
                 retryCount, isScheduled, correlationUid, organisationIdentification, deviceIdentification);
 
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
-
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                TariffSwitchingGetStatusRequestMessageProcessor.this.handleGetStatusDeviceResponse(deviceResponse,
-                        TariffSwitchingGetStatusRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-                if (expected) {
-                    TariffSwitchingGetStatusRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    TariffSwitchingGetStatusRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = TariffSwitchingGetStatusRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                TariffSwitchingGetStatusRequestMessageProcessor.this.checkForRedelivery(new ConnectionFailureException(
-                        ComponentType.PROTOCOL_IEC61850, t.getMessage()), requestMessageData.getCorrelationUid(),
-                        requestMessageData.getOrganisationIdentification(), requestMessageData
-                        .getDeviceIdentification(), requestMessageData.getDomain(), requestMessageData
-                        .getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final DeviceRequest deviceRequest = new DeviceRequest(organisationIdentification, deviceIdentification,
                 correlationUid, domain, domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.getStatus(deviceRequest, deviceResponseHandler);
+        this.deviceService.getStatus(deviceRequest, iec61850DeviceResponseHandler);
+    }
+
+    @Override
+    public void handleDeviceResponse(final DeviceResponse deviceResponse,
+            final com.alliander.osgp.shared.infra.jms.ResponseMessageSender responseMessageSender, final String domain,
+            final String domainVersion, final String messageType, final int retryCount) {
+        LOGGER.info("Override for handleDeviceResponse() by TariffSwitchingGetStatusRequestMessageProcessor");
+        this.handleGetStatusDeviceResponse(deviceResponse, responseMessageSender, domain, domainVersion, messageType,
+                retryCount);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/TariffSwitchingSetScheduleRequestMessageProcessor.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/messaging/processors/TariffSwitchingSetScheduleRequestMessageProcessor.java
@@ -14,16 +14,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
-import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
 import com.alliander.osgp.adapter.protocol.iec61850.device.ssld.requests.SetScheduleDeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.DeviceRequestMessageType;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.SsldDeviceRequestMessageProcessor;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services.Iec61850DeviceResponseHandler;
 import com.alliander.osgp.dto.valueobjects.RelayTypeDto;
 import com.alliander.osgp.dto.valueobjects.ScheduleMessageDataContainerDto;
-import com.alliander.osgp.shared.exceptionhandling.ComponentType;
-import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
 import com.alliander.osgp.shared.infra.jms.Constants;
 
 /**
@@ -85,52 +82,15 @@ public class TariffSwitchingSetScheduleRequestMessageProcessor extends SsldDevic
                 domainVersion, messageType, retryCount, isScheduled, correlationUid, organisationIdentification,
                 deviceIdentification);
 
-        final DeviceResponseHandler deviceResponseHandler = new DeviceResponseHandler() {
+        this.printDomainInfo(messageType, domain, domainVersion);
 
-            @Override
-            public void handleResponse(final DeviceResponse deviceResponse) {
-                TariffSwitchingSetScheduleRequestMessageProcessor.this.handleEmptyDeviceResponse(deviceResponse,
-                        TariffSwitchingSetScheduleRequestMessageProcessor.this.responseMessageSender,
-                        requestMessageData.getDomain(), requestMessageData.getDomainVersion(),
-                        requestMessageData.getMessageType(), requestMessageData.getRetryCount());
-            }
-
-            @Override
-            public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
-
-                if (expected) {
-                    TariffSwitchingSetScheduleRequestMessageProcessor.this.handleExpectedError(
-                            new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                            requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                            requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType());
-                } else {
-                    TariffSwitchingSetScheduleRequestMessageProcessor.this.handleUnExpectedError(deviceResponse, t,
-                            requestMessageData.getMessageData(), requestMessageData.getDomain(),
-                            requestMessageData.getDomainVersion(), requestMessageData.getMessageType(),
-                            requestMessageData.isScheduled(), requestMessageData.getRetryCount());
-                }
-            }
-
-            @Override
-            public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse)
-                    throws JMSException {
-                final int jmsxDeliveryCount = TariffSwitchingSetScheduleRequestMessageProcessor.this
-                        .getJmsXdeliveryCount(message);
-                TariffSwitchingSetScheduleRequestMessageProcessor.this.checkForRedelivery(
-                        new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                        requestMessageData.getCorrelationUid(), requestMessageData.getOrganisationIdentification(),
-                        requestMessageData.getDeviceIdentification(), requestMessageData.getDomain(),
-                        requestMessageData.getDomainVersion(), requestMessageData.getMessageType(), jmsxDeliveryCount);
-            }
-        };
-
-        LOGGER.info("Calling DeviceService function: {} for domain: {} {}", messageType, domain, domainVersion);
+        final Iec61850DeviceResponseHandler iec61850DeviceResponseHandler = this.createIec61850DeviceResponseHandler(
+                requestMessageData, message);
 
         final SetScheduleDeviceRequest deviceRequest = new SetScheduleDeviceRequest(organisationIdentification,
                 deviceIdentification, correlationUid, scheduleMessageDataContainer, RelayTypeDto.TARIFF, domain,
                 domainVersion, messageType, ipAddress, retryCount, isScheduled);
 
-        this.deviceService.setSchedule(deviceRequest, deviceResponseHandler);
+        this.deviceService.setSchedule(deviceRequest, iec61850DeviceResponseHandler);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850Client.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850Client.java
@@ -277,8 +277,7 @@ public class Iec61850Client {
             output = function.apply();
         } catch (final ProtocolAdapterException e) {
             if (retryCount >= this.maxRetryCount) {
-                throw new ConnectionFailureException(
-                        "Could not send command after " + this.maxRetryCount + " attempts", e);
+                throw e;
             } else {
                 this.sendCommandWithRetry(function, deviceIdentification, retryCount + 1);
             }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850Client.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850Client.java
@@ -256,7 +256,7 @@ public class Iec61850Client {
         } catch (final ConnectionFailureException e) {
             throw e;
         } catch (final Exception e) {
-            throw new ProtocolAdapterException("Could not execute command", e);
+            throw new ProtocolAdapterException(e == null ? "Could not execute command" : e.getMessage(), e);
         }
 
         return output;
@@ -283,7 +283,7 @@ public class Iec61850Client {
                 this.sendCommandWithRetry(function, deviceIdentification, retryCount + 1);
             }
         } catch (final Exception e) {
-            throw new ProtocolAdapterException("Could not execute command", e);
+            throw new ProtocolAdapterException(e == null ? "Could not execute command" : e.getMessage(), e);
         }
 
         return output;

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850Client.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850Client.java
@@ -52,13 +52,10 @@ public class Iec61850Client {
     private int iec61850RtuPortServer;
 
     @Autowired
+    private int maxRedeliveriesForIec61850Requests;
+
+    @Autowired
     private int maxRetryCount;
-
-    @Autowired
-    private int delayAfterDeviceRegistration;
-
-    @Autowired
-    private boolean isReportingAfterDeviceRegistrationEnabled;
 
     @Autowired
     private DeviceManagementService deviceManagementService;
@@ -66,10 +63,9 @@ public class Iec61850Client {
     @PostConstruct
     private void init() {
         LOGGER.info(
-                "portClient: {}, portClientLocal: {}, iec61850SsldPortServer: {}, iec61850RtuPortServer: {}, maxRetryCount: {}, delayAfterDeviceRegistration: {}, isReportingAfterDeviceRegistrationEnabled: {}",
+                "portClient: {}, portClientLocal: {}, iec61850SsldPortServer: {}, iec61850RtuPortServer: {}, maxRetryCount: {}, maxRedeliveriesForIec61850Requests: {}",
                 this.iec61850PortClient, this.iec61850PortClientLocal, this.iec61850SsldPortServer,
-                this.iec61850RtuPortServer, this.maxRetryCount, this.delayAfterDeviceRegistration,
-                this.isReportingAfterDeviceRegistrationEnabled);
+                this.iec61850RtuPortServer, this.maxRetryCount, this.maxRedeliveriesForIec61850Requests);
     }
 
     /**
@@ -98,8 +94,9 @@ public class Iec61850Client {
         // connect using SSL.
         final ClientSap clientSap = new ClientSap();
         final Iec61850ClientAssociation clientAssociation;
-        LOGGER.info("Attempting to connect to server: {} on port: {} with max retry count: {}",
-                ipAddress.getHostAddress(), port, this.maxRetryCount);
+        LOGGER.info(
+                "Attempting to connect to server: {} on port: {}, max redelivery count: {} and max retry count: {}",
+                ipAddress.getHostAddress(), port, this.maxRedeliveriesForIec61850Requests, this.maxRetryCount);
 
         try {
             final ClientAssociation association = clientSap.associate(ipAddress, port, null, reportListener);
@@ -242,7 +239,8 @@ public class Iec61850Client {
      *
      * @return The given T.
      */
-    public <T> T sendCommandWithRetry(final Function<T> function) throws ProtocolAdapterException {
+    public <T> T sendCommandWithRetry(final Function<T> function, final String deviceIdentification)
+            throws ProtocolAdapterException {
         T output = null;
 
         try {
@@ -251,7 +249,7 @@ public class Iec61850Client {
             if (ConnectionState.OK.equals(e.getConnectionState())) {
                 // ServiceError means we have to retry.
                 LOGGER.error("Caught ServiceError, retrying", e);
-                this.sendCommandWithRetry(function, 1);
+                this.sendCommandWithRetry(function, deviceIdentification, 1);
             } else {
                 LOGGER.error("Caught IOException, connection with device is broken.", e);
             }
@@ -267,19 +265,22 @@ public class Iec61850Client {
     /**
      * Basically the same as sendCommandWithRetry, but with a retry parameter.
      */
-    private <T> T sendCommandWithRetry(final Function<T> function, final int retryCount)
-            throws ProtocolAdapterException {
+    private <T> T sendCommandWithRetry(final Function<T> function, final String deviceIdentification,
+            final int retryCount) throws ProtocolAdapterException {
 
         T output = null;
+
+        LOGGER.info("retry: {} of {} for deviceIdentification: {}", retryCount, this.maxRetryCount,
+                deviceIdentification);
 
         try {
             output = function.apply();
         } catch (final ProtocolAdapterException e) {
             if (retryCount >= this.maxRetryCount) {
-                throw new ConnectionFailureException("Could not send command after " + this.maxRetryCount + " attemps",
-                        e);
+                throw new ConnectionFailureException(
+                        "Could not send command after " + this.maxRetryCount + " attempts", e);
             } else {
-                this.sendCommandWithRetry(function, retryCount + 1);
+                this.sendCommandWithRetry(function, deviceIdentification, retryCount + 1);
             }
         } catch (final Exception e) {
             throw new ProtocolAdapterException("Could not execute command", e);

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850Connection.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/Iec61850Connection.java
@@ -7,6 +7,7 @@
  */
 package com.alliander.osgp.adapter.protocol.iec61850.infra.networking;
 
+import org.joda.time.DateTime;
 import org.openmuc.openiec61850.ClientAssociation;
 import org.openmuc.openiec61850.ServerModel;
 
@@ -16,9 +17,19 @@ public class Iec61850Connection {
 
     private ServerModel serverModel;
 
+    private DateTime connectionStartTime;
+
     public Iec61850Connection(final Iec61850ClientAssociation clientAssociation, final ServerModel serverModel) {
         this.clientAssociation = clientAssociation;
         this.serverModel = serverModel;
+        this.connectionStartTime = null;
+    }
+
+    public Iec61850Connection(final Iec61850ClientAssociation clientAssociation, final ServerModel serverModel,
+            final DateTime connectionStartTime) {
+        this.clientAssociation = clientAssociation;
+        this.serverModel = serverModel;
+        this.connectionStartTime = connectionStartTime;
     }
 
     public Iec61850ClientAssociation getIec61850ClientAssociation() {
@@ -31,5 +42,9 @@ public class Iec61850Connection {
 
     public ServerModel getServerModel() {
         return this.serverModel;
+    }
+
+    public DateTime getConnectionStartTime() {
+        return this.connectionStartTime;
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/helper/RequestMessageData.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/helper/RequestMessageData.java
@@ -10,7 +10,7 @@ package com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper;
 import java.io.Serializable;
 
 /**
- * An value object, containing all data of an incoming ObjectMessage
+ * A value object, containing all data of an incoming ObjectMessage.
  */
 public class RequestMessageData {
 
@@ -23,6 +23,9 @@ public class RequestMessageData {
     final String correlationUid;
     final String organisationIdentification;
     final String deviceIdentification;
+    final String ipAddress;
+    final int messagePriority;
+    final Long scheduleTime;
 
     public RequestMessageData(final Serializable messageData, final String domain, final String domainVersion,
             final String messageType, final int retryCount, final boolean isScheduled, final String correlationUid,
@@ -36,6 +39,27 @@ public class RequestMessageData {
         this.correlationUid = correlationUid;
         this.organisationIdentification = organisationIdentification;
         this.deviceIdentification = deviceIdentification;
+        this.ipAddress = null;
+        this.messagePriority = 0;
+        this.scheduleTime = null;
+    }
+
+    public RequestMessageData(final Serializable messageData, final String domain, final String domainVersion,
+            final String messageType, final int retryCount, final Boolean isScheduled, final String correlationUid,
+            final String organisationIdentification, final String deviceIdentification, final String ipAddress,
+            final int messagePriority, final Long scheduleTime) {
+        this.messageData = messageData;
+        this.domain = domain;
+        this.domainVersion = domainVersion;
+        this.messageType = messageType;
+        this.retryCount = retryCount;
+        this.isScheduled = isScheduled;
+        this.correlationUid = correlationUid;
+        this.organisationIdentification = organisationIdentification;
+        this.deviceIdentification = deviceIdentification;
+        this.ipAddress = ipAddress;
+        this.messagePriority = messagePriority;
+        this.scheduleTime = scheduleTime;
     }
 
     public Serializable getMessageData() {
@@ -72,5 +96,17 @@ public class RequestMessageData {
 
     public String getDeviceIdentification() {
         return this.deviceIdentification;
+    }
+
+    public String getIpAddress() {
+        return this.ipAddress;
+    }
+
+    public int getMessagePriority() {
+        return this.messagePriority;
+    }
+
+    public Long getScheduleTime() {
+        return this.scheduleTime;
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/reporting/Iec61850ClientSSLDEventListener.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/reporting/Iec61850ClientSSLDEventListener.java
@@ -83,7 +83,7 @@ public class Iec61850ClientSSLDEventListener extends Iec61850ClientBaseEventList
 
     private Map<Integer, Integer> buildExternalByInternalIndexMap(
             final DeviceManagementService deviceManagementService, final String deviceIdentification)
-            throws ProtocolAdapterException {
+                    throws ProtocolAdapterException {
 
         final Map<Integer, Integer> indexMap = new TreeMap<>();
         indexMap.put(0, 0);
@@ -158,8 +158,8 @@ public class Iec61850ClientSSLDEventListener extends Iec61850ClientBaseEventList
     private String getReportDescription(final Report report, final DateTime timeOfEntry) {
         return String.format("device: %s, reportId: %s, timeOfEntry: %s, sqNum: %s%s%s", this.deviceIdentification,
                 report.getRptId(), timeOfEntry == null ? "-" : timeOfEntry, report.getSqNum(),
-                        report.getSubSqNum() == null ? "" : " subSqNum: " + report.getSubSqNum(),
-                                report.isMoreSegmentsFollow() ? " (more segments follow for this sqNum)" : "");
+                report.getSubSqNum() == null ? "" : " subSqNum: " + report.getSubSqNum(),
+                report.isMoreSegmentsFollow() ? " (more segments follow for this sqNum)" : "");
     }
 
     private void addEventNotificationForReportedData(final FcModelNode evnRpn, final DateTime timeOfEntry,
@@ -264,7 +264,7 @@ public class Iec61850ClientSSLDEventListener extends Iec61850ClientBaseEventList
             /*
              * Use the reports time of entry for the event. The trigger time
              * will appear in the description with the event notification.
-             * 
+             *
              * See: determineDescription(FcModelNode)
              */
             return timeOfEntry;
@@ -292,30 +292,30 @@ public class Iec61850ClientSSLDEventListener extends Iec61850ClientBaseEventList
         sb.append("\t           BufOvfl:\t").append(report.isBufOvfl()).append(System.lineSeparator());
         sb.append("\t           EntryId:\t").append(report.getEntryId()).append(System.lineSeparator());
         sb.append("\tInclusionBitString:\t").append(Arrays.toString(report.getInclusionBitString()))
-        .append(System.lineSeparator());
+                .append(System.lineSeparator());
         sb.append("\tMoreSegmentsFollow:\t").append(report.isMoreSegmentsFollow()).append(System.lineSeparator());
         sb.append("\t             SqNum:\t").append(report.getSqNum()).append(System.lineSeparator());
         sb.append("\t          SubSqNum:\t").append(report.getSubSqNum()).append(System.lineSeparator());
         sb.append("\t       TimeOfEntry:\t").append(report.getTimeOfEntry()).append(System.lineSeparator());
         if (report.getTimeOfEntry() != null) {
             sb.append("\t                   \t(")
-            .append(new DateTime(report.getTimeOfEntry().getTimestampValue() + IEC61850_ENTRY_TIME_OFFSET))
-            .append(')').append(System.lineSeparator());
+                    .append(new DateTime(report.getTimeOfEntry().getTimestampValue() + IEC61850_ENTRY_TIME_OFFSET))
+                    .append(')').append(System.lineSeparator());
         }
         final List<BdaReasonForInclusion> reasonCodes = report.getReasonCodes();
         if (reasonCodes != null && !reasonCodes.isEmpty()) {
             sb.append("\t       ReasonCodes:").append(System.lineSeparator());
             for (final BdaReasonForInclusion reasonCode : reasonCodes) {
                 sb.append("\t                   \t")
-                .append(reasonCode.getReference() == null ? HexConverter.toHexString(reasonCode.getValue())
-                        : reasonCode).append("\t(")
+                        .append(reasonCode.getReference() == null ? HexConverter.toHexString(reasonCode.getValue())
+                                : reasonCode).append("\t(")
                         .append(new Iec61850BdaReasonForInclusionHelper(reasonCode).getInfo()).append(')')
                         .append(System.lineSeparator());
             }
         }
         sb.append("\t           optFlds:").append(report.getOptFlds()).append("\t(")
-        .append(new Iec61850BdaOptFldsHelper(report.getOptFlds()).getInfo()).append(')')
-        .append(System.lineSeparator());
+                .append(new Iec61850BdaOptFldsHelper(report.getOptFlds()).getInfo()).append(')')
+                .append(System.lineSeparator());
         final DataSet dataSet = report.getDataSet();
         if (dataSet == null) {
             sb.append("\t           DataSet:\tnull").append(System.lineSeparator());
@@ -403,7 +403,7 @@ public class Iec61850ClientSSLDEventListener extends Iec61850ClientBaseEventList
 
     @Override
     public void associationClosed(final IOException e) {
-        this.logger.info("associationClosed for device: {}, {}", this.deviceIdentification,
+        this.logger.info("associationClosed() for device: {}, {}", this.deviceIdentification,
                 e == null ? "no IOException" : "IOException: " + e.getMessage());
 
         synchronized (this.eventNotifications) {

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceConnectionService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceConnectionService.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.alliander.osgp.adapter.protocol.iec61850.application.services.DeviceManagementService;
+import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceRequest;
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.ConnectionFailureException;
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.NodeReadException;
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.ProtocolAdapterException;
@@ -30,6 +31,7 @@ import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850Cli
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850ClientAssociation;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850Connection;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.DataAttribute;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.DeviceConnection;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.Function;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.IED;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.LogicalDevice;
@@ -65,17 +67,27 @@ public class Iec61850DeviceConnectionService {
     @Autowired
     private boolean isIcdFileUsed;
 
-    public synchronized void connect(final String ipAddress, final String deviceIdentification, final IED ied,
-            final LogicalDevice logicalDevice) throws ConnectionFailureException {
+    public synchronized DeviceConnection connectWithoutConnectionCashing(final String ipAddress,
+            final String deviceIdentification, final IED ied, final LogicalDevice logicalDevice)
+            throws ConnectionFailureException {
+        return this.connect(ipAddress, deviceIdentification, ied, logicalDevice, false);
+    }
+
+    public synchronized DeviceConnection connect(final String ipAddress, final String deviceIdentification,
+            final IED ied, final LogicalDevice logicalDevice) throws ConnectionFailureException {
+        return this.connect(ipAddress, deviceIdentification, ied, logicalDevice, true);
+    }
+
+    public synchronized DeviceConnection connect(final String ipAddress, final String deviceIdentification,
+            final IED ied, final LogicalDevice logicalDevice, final boolean cacheConnection)
+                    throws ConnectionFailureException {
         LOGGER.info("Trying to find connection in cache for deviceIdentification: {}", deviceIdentification);
 
-        if (this.testIfConnectionIsCachedAndAlive(deviceIdentification, ied, logicalDevice)) {
-            return;
+        if (cacheConnection && this.testIfConnectionIsCachedAndAlive(deviceIdentification, ied, logicalDevice)) {
+            return new DeviceConnection(this.fetchIec61850Connection(deviceIdentification), deviceIdentification, ied);
         }
         final InetAddress inetAddress = this.convertIpAddress(ipAddress);
-        if (inetAddress == null) {
-            return;
-        }
+
         // Connect to obtain ClientAssociation and ServerModel.
         LOGGER.info("Trying to connect to deviceIdentification: {} at IP address {} using response time-out: {}",
                 deviceIdentification, ipAddress, this.responseTimeout);
@@ -120,13 +132,18 @@ public class Iec61850DeviceConnectionService {
         }
 
         // Cache the connection.
-        this.cacheIec61850Connection(deviceIdentification, new Iec61850Connection(iec61850ClientAssociation,
-                serverModel));
+        final Iec61850Connection iec61850Connection = new Iec61850Connection(iec61850ClientAssociation, serverModel,
+                startTime);
+        if (cacheConnection) {
+            this.cacheIec61850Connection(deviceIdentification, iec61850Connection);
+        }
 
         final DateTime endTime = DateTime.now();
         LOGGER.info(
                 "Connected to device: {}, fetched server model. Start time: {}, end time: {}, total time in milliseconds: {}",
                 deviceIdentification, startTime, endTime, endTime.minus(startTime.getMillis()).getMillis());
+
+        return new DeviceConnection(iec61850Connection, deviceIdentification, ied);
     }
 
     private boolean testIfConnectionIsCachedAndAlive(final String deviceIdentification, final IED ied,
@@ -204,6 +221,29 @@ public class Iec61850DeviceConnectionService {
         }
     }
 
+    public synchronized void disconnect(final DeviceConnection deviceConnection, final DeviceRequest deviceRequest) {
+        try {
+            deviceConnection.getConnection().getIec61850ClientAssociation().getClientAssociation().disconnect();
+            this.logDuration(deviceConnection, deviceRequest);
+        } catch (final NullPointerException e) {
+            LOGGER.debug("NullPointerException during disconnect()", e);
+        }
+    }
+
+    private void logDuration(final DeviceConnection deviceConnection, final DeviceRequest deviceRequest) {
+        if (deviceConnection == null) {
+            return;
+        }
+        if (deviceRequest == null) {
+            return;
+        }
+        final DateTime endTime = DateTime.now();
+        final DateTime startTime = deviceConnection.getConnection().getConnectionStartTime();
+        LOGGER.info("Device: {}, messageType: {}, Start time: {}, end time: {}, total time in milliseconds: {}",
+                deviceConnection.getDeviceIdentification(), deviceRequest.getMessageType(), startTime, endTime, endTime
+                .minus(startTime.getMillis()).getMillis());
+    }
+
     public Iec61850ClientAssociation getIec61850ClientAssociation(final String deviceIdentification) {
         final Iec61850Connection iec61850Connection = this.fetchIec61850Connection(deviceIdentification);
         return iec61850Connection.getIec61850ClientAssociation();
@@ -227,6 +267,10 @@ public class Iec61850DeviceConnectionService {
         return this.iec61850Client;
     }
 
+    public Iec61850Connection getIec61850Connection(final String deviceIdentification) {
+        return this.fetchIec61850Connection(deviceIdentification);
+    }
+
     public void readAllValues(final String deviceIdentification) throws NodeReadException {
         final Iec61850Connection iec61850Connection = this.fetchIec61850Connection(deviceIdentification);
         if (iec61850Connection == null) {
@@ -236,7 +280,7 @@ public class Iec61850DeviceConnectionService {
         this.iec61850Client.readAllDataValues(clientAssociation);
     }
 
-    public void readNodeDateValues(final String deviceIdentification, final FcModelNode fcModelNode)
+    public void readNodeDataValues(final String deviceIdentification, final FcModelNode fcModelNode)
             throws NodeReadException {
         final Iec61850Connection iec61850Connection = this.fetchIec61850Connection(deviceIdentification);
         if (iec61850Connection == null) {
@@ -246,8 +290,9 @@ public class Iec61850DeviceConnectionService {
         this.iec61850Client.readNodeDataValues(clientAssociation, fcModelNode);
     }
 
-    public <T> T sendCommandWithRetry(final Function<T> function) throws ProtocolAdapterException {
-        return this.iec61850Client.sendCommandWithRetry(function);
+    public <T> T sendCommandWithRetry(final Function<T> function, final String deviceIdentification)
+            throws ProtocolAdapterException {
+        return this.iec61850Client.sendCommandWithRetry(function, deviceIdentification);
     }
 
     private void cacheIec61850Connection(final String deviceIdentification, final Iec61850Connection iec61850Connection) {
@@ -266,12 +311,12 @@ public class Iec61850DeviceConnectionService {
         cache.remove(deviceIdentification);
     }
 
-    private InetAddress convertIpAddress(final String ipAddress) {
+    private InetAddress convertIpAddress(final String ipAddress) throws ConnectionFailureException {
         try {
             return InetAddress.getByName(ipAddress);
         } catch (final UnknownHostException e) {
             LOGGER.error("Unexpected exception during convertIpAddress", e);
-            return null;
+            throw new ConnectionFailureException(e.getMessage(), e);
         }
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceConnectionService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceConnectionService.java
@@ -67,22 +67,21 @@ public class Iec61850DeviceConnectionService {
     @Autowired
     private boolean isIcdFileUsed;
 
-    public synchronized DeviceConnection connectWithoutConnectionCashing(final String ipAddress,
-            final String deviceIdentification, final IED ied, final LogicalDevice logicalDevice)
-            throws ConnectionFailureException {
+    public DeviceConnection connectWithoutConnectionCaching(final String ipAddress, final String deviceIdentification,
+            final IED ied, final LogicalDevice logicalDevice) throws ConnectionFailureException {
         return this.connect(ipAddress, deviceIdentification, ied, logicalDevice, false);
     }
 
-    public synchronized DeviceConnection connect(final String ipAddress, final String deviceIdentification,
-            final IED ied, final LogicalDevice logicalDevice) throws ConnectionFailureException {
+    public DeviceConnection connect(final String ipAddress, final String deviceIdentification, final IED ied,
+            final LogicalDevice logicalDevice) throws ConnectionFailureException {
         return this.connect(ipAddress, deviceIdentification, ied, logicalDevice, true);
     }
 
     public synchronized DeviceConnection connect(final String ipAddress, final String deviceIdentification,
             final IED ied, final LogicalDevice logicalDevice, final boolean cacheConnection)
                     throws ConnectionFailureException {
-        LOGGER.info("Trying to find connection in cache for deviceIdentification: {}", deviceIdentification);
-
+        // When connection-caching is used, check if a connection is available
+        // an usable for the given deviceIdentification.
         if (cacheConnection && this.testIfConnectionIsCachedAndAlive(deviceIdentification, ied, logicalDevice)) {
             return new DeviceConnection(this.fetchIec61850Connection(deviceIdentification), deviceIdentification, ied);
         }
@@ -149,6 +148,7 @@ public class Iec61850DeviceConnectionService {
     private boolean testIfConnectionIsCachedAndAlive(final String deviceIdentification, final IED ied,
             final LogicalDevice logicalDevice) {
         try {
+            LOGGER.info("Trying to find connection in cache for deviceIdentification: {}", deviceIdentification);
             final Iec61850Connection iec61850Connection = this.fetchIec61850Connection(deviceIdentification);
             if (iec61850Connection != null) {
                 // Already connected, check if connection is still usable.

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceResponseHandler.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceResponseHandler.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2014-2016 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.jms.JMSException;
+
+import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse;
+import com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler;
+import com.alliander.osgp.adapter.protocol.iec61850.domain.valueobjects.DomainInformation;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.messaging.BaseMessageProcessor;
+import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.RequestMessageData;
+import com.alliander.osgp.shared.exceptionhandling.ComponentType;
+import com.alliander.osgp.shared.exceptionhandling.ConnectionFailureException;
+import com.alliander.osgp.shared.infra.jms.DeviceMessageMetadata;
+import com.alliander.osgp.shared.infra.jms.ResponseMessageSender;
+
+public class Iec61850DeviceResponseHandler implements DeviceResponseHandler {
+
+    private final BaseMessageProcessor messageProcessor;
+    private final Integer jmsxDeliveryCount;
+    private final DeviceMessageMetadata deviceMessageMetadata;
+    private final DomainInformation domainInformation;
+    private final Integer retryCount;
+    private final Boolean isScheduled;
+    private final Serializable messageData;
+    private final ResponseMessageSender responseMessageSender;
+
+    public Iec61850DeviceResponseHandler(final BaseMessageProcessor messageProcessor, final Integer jmsxDeliveryCount,
+            final RequestMessageData requestMessageData, final ResponseMessageSender responseMessageSender) {
+        this.messageProcessor = messageProcessor;
+        this.jmsxDeliveryCount = jmsxDeliveryCount;
+        this.deviceMessageMetadata = new DeviceMessageMetadata(requestMessageData.getDeviceIdentification(),
+                requestMessageData.getOrganisationIdentification(), requestMessageData.getCorrelationUid(),
+                requestMessageData.getMessageType(), requestMessageData.getMessagePriority());
+        this.domainInformation = new DomainInformation(requestMessageData.getDomain(),
+                requestMessageData.getDomainVersion());
+        this.retryCount = requestMessageData.getRetryCount();
+        this.isScheduled = requestMessageData.isScheduled();
+        this.messageData = requestMessageData.getMessageData();
+        this.responseMessageSender = responseMessageSender;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler
+     * #handleResponse(com.alliander.osgp.adapter.protocol.iec61850.device.
+     * DeviceResponse)
+     */
+    @Override
+    public void handleResponse(final DeviceResponse deviceResponse) {
+        this.messageProcessor.handleDeviceResponse(deviceResponse, this.responseMessageSender,
+                this.domainInformation.getDomain(), this.domainInformation.getDomainVersion(),
+                this.deviceMessageMetadata.getMessageType(), this.retryCount);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler
+     * #handleConnectionFailure(java.lang.Throwable,
+     * com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse)
+     */
+    @Override
+    public void handleConnectionFailure(final Throwable t, final DeviceResponse deviceResponse) throws JMSException {
+        Objects.requireNonNull(t, "handleConnectionFailure() Throwable t may not be null");
+        final ConnectionFailureException connectionFailureException = new ConnectionFailureException(
+                ComponentType.PROTOCOL_IEC61850, t.getMessage());
+
+        this.messageProcessor.checkForRedelivery(this.deviceMessageMetadata, connectionFailureException,
+                this.domainInformation.getDomain(), this.domainInformation.getDomainVersion(), this.jmsxDeliveryCount);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler
+     * #handleException(java.lang.Throwable,
+     * com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse,
+     * boolean)
+     */
+    @Override
+    public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
+        Objects.requireNonNull(t, "handleException() Throwable t may not be null");
+        if (expected) {
+            this.messageProcessor.handleExpectedError(
+                    new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
+                    this.deviceMessageMetadata.getCorrelationUid(),
+                    this.deviceMessageMetadata.getOrganisationIdentification(),
+                    this.deviceMessageMetadata.getDeviceIdentification(), this.domainInformation.getDomain(),
+                    this.domainInformation.getDomainVersion(), this.deviceMessageMetadata.getMessageType());
+        } else {
+            this.messageProcessor.handleUnExpectedError(deviceResponse, t, this.messageData,
+                    this.domainInformation.getDomain(), this.domainInformation.getDomainVersion(),
+                    this.deviceMessageMetadata.getMessageType(), this.isScheduled, this.retryCount);
+        }
+    }
+}

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceResponseHandler.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceResponseHandler.java
@@ -76,7 +76,6 @@ public class Iec61850DeviceResponseHandler implements DeviceResponseHandler {
         Objects.requireNonNull(t, "handleConnectionFailure() Throwable t may not be null");
         final ConnectionFailureException connectionFailureException = new ConnectionFailureException(
                 ComponentType.PROTOCOL_IEC61850, t.getMessage());
-
         this.messageProcessor.checkForRedelivery(this.deviceMessageMetadata, connectionFailureException,
                 this.domainInformation.getDomain(), this.domainInformation.getDomainVersion(), this.jmsxDeliveryCount);
     }
@@ -87,23 +86,13 @@ public class Iec61850DeviceResponseHandler implements DeviceResponseHandler {
      * @see
      * com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponseHandler
      * #handleException(java.lang.Throwable,
-     * com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse,
-     * boolean)
+     * com.alliander.osgp.adapter.protocol.iec61850.device.DeviceResponse)
      */
     @Override
-    public void handleException(final Throwable t, final DeviceResponse deviceResponse, final boolean expected) {
+    public void handleException(final Throwable t, final DeviceResponse deviceResponse) {
         Objects.requireNonNull(t, "handleException() Throwable t may not be null");
-        if (expected) {
-            this.messageProcessor.handleExpectedError(
-                    new ConnectionFailureException(ComponentType.PROTOCOL_IEC61850, t.getMessage()),
-                    this.deviceMessageMetadata.getCorrelationUid(),
-                    this.deviceMessageMetadata.getOrganisationIdentification(),
-                    this.deviceMessageMetadata.getDeviceIdentification(), this.domainInformation.getDomain(),
-                    this.domainInformation.getDomainVersion(), this.deviceMessageMetadata.getMessageType());
-        } else {
-            this.messageProcessor.handleUnExpectedError(deviceResponse, t, this.messageData,
-                    this.domainInformation.getDomain(), this.domainInformation.getDomainVersion(),
-                    this.deviceMessageMetadata.getMessageType(), this.isScheduled, this.retryCount);
-        }
+        this.messageProcessor.handleUnExpectedError(deviceResponse, t, this.messageData,
+                this.domainInformation.getDomain(), this.domainInformation.getDomainVersion(),
+                this.deviceMessageMetadata.getMessageType(), this.isScheduled, this.retryCount);
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850RtuDeviceService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850RtuDeviceService.java
@@ -10,6 +10,8 @@ package com.alliander.osgp.adapter.protocol.iec61850.infra.networking.services;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.jms.JMSException;
+
 import org.openmuc.openiec61850.ClientAssociation;
 import org.openmuc.openiec61850.Fc;
 import org.openmuc.openiec61850.ServerModel;
@@ -64,7 +66,8 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
     private Iec61850Client iec61850Client;
 
     @Override
-    public void getData(final GetDataDeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler) {
+    public void getData(final GetDataDeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler)
+            throws JMSException {
         try {
             final ServerModel serverModel = this.connectAndRetrieveServerModel(deviceRequest);
 
@@ -87,7 +90,7 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
                     deviceRequest.getCorrelationUid(), DeviceMessageStatus.FAILURE);
 
-            deviceResponseHandler.handleException(se, deviceResponse, true);
+            deviceResponseHandler.handleConnectionFailure(se, deviceResponse);
         } catch (final Exception e) {
             LOGGER.error("Unexpected exception during Get Data", e);
 
@@ -95,13 +98,13 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
                     deviceRequest.getCorrelationUid(), DeviceMessageStatus.FAILURE);
 
-            deviceResponseHandler.handleException(e, deviceResponse, false);
+            deviceResponseHandler.handleException(e, deviceResponse);
         }
     }
 
     @Override
     public void setSetPoints(final SetSetPointsDeviceRequest deviceRequest,
-            final DeviceResponseHandler deviceResponseHandler) {
+            final DeviceResponseHandler deviceResponseHandler) throws JMSException {
         try {
             final ServerModel serverModel = this.connectAndRetrieveServerModel(deviceRequest);
             final ClientAssociation clientAssociation = this.iec61850DeviceConnectionService
@@ -109,7 +112,7 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
 
             this.setSetPoints(new DeviceConnection(new Iec61850Connection(new Iec61850ClientAssociation(
                     clientAssociation, null), serverModel), deviceRequest.getDeviceIdentification(), IED.ZOWN_RTU),
-                            serverModel, clientAssociation, deviceRequest);
+                    serverModel, clientAssociation, deviceRequest);
 
             final EmptyDeviceResponse deviceResponse = new EmptyDeviceResponse(
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
@@ -123,7 +126,7 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
                     deviceRequest.getCorrelationUid(), DeviceMessageStatus.FAILURE);
 
-            deviceResponseHandler.handleException(se, deviceResponse, true);
+            deviceResponseHandler.handleConnectionFailure(se, deviceResponse);
         } catch (final Exception e) {
             LOGGER.error("Unexpected exception during Set SetPoint", e);
 
@@ -131,13 +134,13 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
                     deviceRequest.getCorrelationUid(), DeviceMessageStatus.FAILURE);
 
-            deviceResponseHandler.handleException(e, deviceResponse, false);
+            deviceResponseHandler.handleException(e, deviceResponse);
         }
     }
 
     private void setSetPoints(final DeviceConnection connection, final ServerModel serverModel,
             final ClientAssociation clientAssociation, final SetSetPointsDeviceRequest deviceRequest)
-                    throws ProtocolAdapterException {
+            throws ProtocolAdapterException {
 
         final SetPointsRequestDto setPointsRequest = deviceRequest.getSetPointsRequest();
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850RtuDeviceService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850RtuDeviceService.java
@@ -71,9 +71,9 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
             final ClientAssociation clientAssociation = this.iec61850DeviceConnectionService
                     .getClientAssociation(deviceRequest.getDeviceIdentification());
 
-            final DataResponseDto getDataResponse = this.getData(new DeviceConnection(
-                    new Iec61850Connection(new Iec61850ClientAssociation(clientAssociation, null), serverModel),
-                    deviceRequest.getDeviceIdentification(), IED.ZOWN_RTU), deviceRequest);
+            final DataResponseDto getDataResponse = this.getData(
+                    new DeviceConnection(new Iec61850Connection(new Iec61850ClientAssociation(clientAssociation, null),
+                            serverModel), deviceRequest.getDeviceIdentification(), IED.ZOWN_RTU), deviceRequest);
 
             final GetDataDeviceResponse deviceResponse = new GetDataDeviceResponse(
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
@@ -107,11 +107,9 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
             final ClientAssociation clientAssociation = this.iec61850DeviceConnectionService
                     .getClientAssociation(deviceRequest.getDeviceIdentification());
 
-            this.setSetPoints(
-                    new DeviceConnection(
-                            new Iec61850Connection(new Iec61850ClientAssociation(clientAssociation, null), serverModel),
-                            deviceRequest.getDeviceIdentification(), IED.ZOWN_RTU),
-                    serverModel, clientAssociation, deviceRequest);
+            this.setSetPoints(new DeviceConnection(new Iec61850Connection(new Iec61850ClientAssociation(
+                    clientAssociation, null), serverModel), deviceRequest.getDeviceIdentification(), IED.ZOWN_RTU),
+                            serverModel, clientAssociation, deviceRequest);
 
             final EmptyDeviceResponse deviceResponse = new EmptyDeviceResponse(
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
@@ -139,7 +137,7 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
 
     private void setSetPoints(final DeviceConnection connection, final ServerModel serverModel,
             final ClientAssociation clientAssociation, final SetSetPointsDeviceRequest deviceRequest)
-            throws ProtocolAdapterException {
+                    throws ProtocolAdapterException {
 
         final SetPointsRequestDto setPointsRequest = deviceRequest.getSetPointsRequest();
 
@@ -158,7 +156,7 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
             }
         };
 
-        this.iec61850Client.sendCommandWithRetry(function);
+        this.iec61850Client.sendCommandWithRetry(function, deviceRequest.getDeviceIdentification());
     }
 
     // ======================================
@@ -211,7 +209,7 @@ public class Iec61850RtuDeviceService implements RtuDeviceService {
             }
         };
 
-        return this.iec61850Client.sendCommandWithRetry(function);
+        return this.iec61850Client.sendCommandWithRetry(function, deviceRequest.getDeviceIdentification());
     }
 
     // ===========================

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850SsldDeviceService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850SsldDeviceService.java
@@ -12,7 +12,8 @@ import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import org.openmuc.openiec61850.ServerModel;
+import javax.jms.JMSException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,8 +41,6 @@ import com.alliander.osgp.adapter.protocol.iec61850.domain.valueobjects.EventTyp
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.ConnectionFailureException;
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.ProtocolAdapterException;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850Client;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850ClientAssociation;
-import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850Connection;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.DeviceConnection;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.IED;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.LogicalDevice;
@@ -91,7 +90,7 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
     @Autowired
     private Iec61850Mapper mapper;
 
-    // Timeout between the SetLight and getStatus during the device self-test
+    // Timeout between the setLight and getStatus during the device self-test
     @Autowired
     private int selftestTimeout;
 
@@ -99,9 +98,11 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
     private int disconnectDelay;
 
     @Override
-    public void getStatus(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler) {
+    public void getStatus(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler)
+            throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             // Getting the SSLD for the device output-settings.
             final Ssld ssld = this.ssldDataService.findDevice(deviceRequest.getDeviceIdentification());
@@ -119,14 +120,15 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
     public void getPowerUsageHistory(final GetPowerUsageHistoryDeviceRequest deviceRequest,
-            final DeviceResponseHandler deviceResponseHandler) {
+            final DeviceResponseHandler deviceResponseHandler) throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             // Getting the SSLD for the device output-settings.
             final Ssld ssld = this.ssldDataService.findDevice(deviceRequest.getDeviceIdentification());
@@ -148,68 +150,122 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
-    public void setLight(final SetLightDeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler) {
+    public void setLight(final SetLightDeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler)
+            throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             // Getting the SSLD for the device output-settings.
             final Ssld ssld = this.ssldDataService.findDevice(deviceRequest.getDeviceIdentification());
+            final List<DeviceOutputSetting> deviceOutputSettings = this.ssldDataService.findByRelayType(ssld,
+                    RelayType.LIGHT);
+            final List<LightValueDto> lightValues = deviceRequest.getLightValuesContainer().getLightValues();
+            List<LightValueDto> relaysWithInternalIdToSwitch;
+
+            // Check if external index 0 is used.
+            final LightValueDto index0LightValue = this.checkForIndex0(lightValues);
+            if (index0LightValue != null) {
+                // If external index 0 is used, create a list of all light
+                // relays according to the device output settings.
+                relaysWithInternalIdToSwitch = this.createListOfInternalIndicesToSwitch(deviceOutputSettings,
+                        index0LightValue.isOn());
+            } else {
+                // Else, create a list of internal indices based on the given
+                // external indices in the light values list.
+                relaysWithInternalIdToSwitch = this.createListOfInternalIndicesToSwitch(deviceOutputSettings,
+                        lightValues);
+            }
+
+            // Switch light relays based on internal indices.
             final Iec61850SetLightCommand iec61850SetLightCommand = new Iec61850SetLightCommand();
-
-            for (final LightValueDto lightValue : deviceRequest.getLightValuesContainer().getLightValues()) {
-                // for index 0, only devices LIGHT RelayTypes have to be
-                // switched
-                boolean switchAllLightRelays = false;
-                if (lightValue == null) {
-                    switchAllLightRelays = true;
-                } else if (lightValue.getIndex() == null) {
-                    switchAllLightRelays = true;
-                } else if (lightValue.getIndex() == 0) {
-                    switchAllLightRelays = true;
-                }
-
-                LOGGER.info("switchAllLightRelays: {}", switchAllLightRelays);
-
-                if (switchAllLightRelays) {
-                    for (final DeviceOutputSetting deviceOutputSetting : this.ssldDataService.findByRelayType(ssld,
-                            RelayType.LIGHT)) {
-                        iec61850SetLightCommand.switchLightRelay(this.iec61850Client, deviceConnection,
-                                deviceOutputSetting.getInternalId(), lightValue.isOn());
-                    }
-                } else {
-
-                    final DeviceOutputSetting deviceOutputSetting = this.ssldDataService
-                            .getDeviceOutputSettingForExternalIndex(ssld, lightValue.getIndex());
-
-                    if (deviceOutputSetting != null) {
-
-                        // You can only switch LIGHT relays that are used
-                        this.checkRelay(deviceOutputSetting.getRelayType(), RelayType.LIGHT,
-                                deviceOutputSetting.getInternalId());
-
-                        iec61850SetLightCommand.switchLightRelay(this.iec61850Client, deviceConnection,
-                                deviceOutputSetting.getInternalId(), lightValue.isOn());
-                    }
+            for (final LightValueDto relayWithInternalIdToSwitch : relaysWithInternalIdToSwitch) {
+                LOGGER.info("Trying to switch light relay with internal index: {} for device: {}",
+                        relayWithInternalIdToSwitch.getIndex(), deviceRequest.getDeviceIdentification());
+                if (!iec61850SetLightCommand.switchLightRelay(this.iec61850Client, deviceConnection,
+                        relayWithInternalIdToSwitch.getIndex(), relayWithInternalIdToSwitch.isOn())) {
+                    throw new ProtocolAdapterException(String.format(
+                            "Failed to switch light relay with internal index: %d for device: %s",
+                            relayWithInternalIdToSwitch.getIndex(), deviceRequest.getDeviceIdentification()));
                 }
             }
+
             this.createSuccessfulDefaultResponse(deviceRequest, deviceResponseHandler);
         } catch (final ConnectionFailureException se) {
             this.handleConnectionFailureException(deviceRequest, deviceResponseHandler, se);
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
+    }
+
+    private LightValueDto checkForIndex0(final List<LightValueDto> lightValues) {
+        for (final LightValueDto lightValue : lightValues) {
+            if (lightValue == null) {
+                break;
+            }
+            if (lightValue.getIndex() == null) {
+                return lightValue;
+            }
+            if (lightValue.getIndex() == 0) {
+                return lightValue;
+            }
+        }
+        return null;
+    }
+
+    private List<LightValueDto> createListOfInternalIndicesToSwitch(
+            final List<DeviceOutputSetting> deviceOutputSettings, final boolean on) {
+        LOGGER.info("creating list of internal indices using device output settings");
+        final List<LightValueDto> relaysWithInternalIdToSwitch = new ArrayList<>();
+        for (final DeviceOutputSetting deviceOutputSetting : deviceOutputSettings) {
+            if (RelayType.LIGHT.equals(deviceOutputSetting.getRelayType())) {
+                final LightValueDto relayWithInternalIdToSwitch = new LightValueDto(
+                        deviceOutputSetting.getInternalId(), on, null);
+                relaysWithInternalIdToSwitch.add(relayWithInternalIdToSwitch);
+            }
+        }
+        return relaysWithInternalIdToSwitch;
+    }
+
+    private List<LightValueDto> createListOfInternalIndicesToSwitch(
+            final List<DeviceOutputSetting> deviceOutputSettings, final List<LightValueDto> lightValues)
+            throws FunctionalException {
+        LOGGER.info("creating list of internal indices using device output settings and external indices from light values");
+        final List<LightValueDto> relaysWithInternalIdToSwitch = new ArrayList<>();
+        for (final LightValueDto lightValue : lightValues) {
+            if (lightValue == null) {
+                break;
+            }
+            DeviceOutputSetting deviceOutputSettingForExternalId = null;
+            for (final DeviceOutputSetting deviceOutputSetting : deviceOutputSettings) {
+                if (deviceOutputSetting.getExternalId() == lightValue.getIndex()) {
+                    // You can only switch LIGHT relays that are used.
+                    this.checkRelay(deviceOutputSetting.getRelayType(), RelayType.LIGHT,
+                            deviceOutputSetting.getInternalId());
+                    deviceOutputSettingForExternalId = deviceOutputSetting;
+                }
+            }
+            if (deviceOutputSettingForExternalId == null) {
+                break;
+            }
+            final LightValueDto relayWithInternalIdToSwitch = new LightValueDto(
+                    deviceOutputSettingForExternalId.getInternalId(), lightValue.isOn(), lightValue.getDimValue());
+            relaysWithInternalIdToSwitch.add(relayWithInternalIdToSwitch);
+        }
+        return relaysWithInternalIdToSwitch;
     }
 
     @Override
     public void setConfiguration(final SetConfigurationDeviceRequest deviceRequest,
-            final DeviceResponseHandler deviceResponseHandler) {
+            final DeviceResponseHandler deviceResponseHandler) throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
             final ConfigurationDto configuration = deviceRequest.getConfiguration();
 
             // Ignoring required, unused fields DALI-configuration, meterType,
@@ -224,13 +280,15 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
-    public void getConfiguration(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler) {
+    public void getConfiguration(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler)
+            throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             // Getting the SSLD for the device output-settings.
             final Ssld ssld = this.ssldDataService.findDevice(deviceRequest.getDeviceIdentification());
@@ -249,13 +307,15 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
-    public void setReboot(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler) {
+    public void setReboot(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler)
+            throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             new Iec61850RebootCommand().rebootDevice(this.iec61850Client, deviceConnection);
 
@@ -265,17 +325,18 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
     public void runSelfTest(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler,
-            final boolean startOfTest) {
+            final boolean startOfTest) throws JMSException {
         // Assuming all goes well.
         final DeviceMessageStatus status = DeviceMessageStatus.OK;
+        DeviceConnection deviceConnection = null;
 
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             // Getting the SSLD for the device output-settings.
             final Ssld ssld = this.ssldDataService.findDevice(deviceRequest.getDeviceIdentification());
@@ -292,23 +353,23 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
             for (final DeviceOutputSetting deviceOutputSetting : this.ssldDataService.findByRelayType(ssld,
                     RelayType.LIGHT)) {
                 lightRelays.add(deviceOutputSetting.getExternalId());
-                iec61850SetLightCommand.switchLightRelay(this.iec61850Client, deviceConnection,
-                        deviceOutputSetting.getInternalId(), startOfTest);
+                if (!iec61850SetLightCommand.switchLightRelay(this.iec61850Client, deviceConnection,
+                        deviceOutputSetting.getInternalId(), startOfTest)) {
+                    throw new ProtocolAdapterException(String.format(
+                            "Failed to switch light relay during self-test with internal index: %d for device: %s",
+                            deviceOutputSetting.getInternalId(), deviceRequest.getDeviceIdentification()));
+                }
             }
 
             // Sleep and wait.
             try {
-                LOGGER.info("Waiting {} seconds before getting the device status", this.selftestTimeout / 1000);
+                LOGGER.info("Waiting {} milliseconds before getting the device status", this.selftestTimeout);
                 Thread.sleep(this.selftestTimeout);
             } catch (final InterruptedException e) {
                 LOGGER.error("An error occured during the device selftest timeout.", e);
                 throw new TechnicalException(ComponentType.PROTOCOL_IEC61850,
                         "An error occured during the device selftest timeout.");
             }
-
-            // Reconnecting to the device.
-            this.iec61850DeviceConnectionService.connect(deviceRequest.getIpAddress(),
-                    deviceRequest.getDeviceIdentification(), IED.FLEX_OVL, LogicalDevice.LIGHTING);
 
             // Getting the status.
             final DeviceStatusDto deviceStatus = new Iec61850GetStatusCommand().getStatusFromDevice(
@@ -333,14 +394,15 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
     public void setSchedule(final SetScheduleDeviceRequest deviceRequest,
-            final DeviceResponseHandler deviceResponseHandler) {
+            final DeviceResponseHandler deviceResponseHandler) throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             // Getting the SSLD for the device output-settings.
             final Ssld ssld = this.ssldDataService.findDevice(deviceRequest.getDeviceIdentification());
@@ -357,13 +419,15 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
-    public void getFirmwareVersion(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler) {
+    public void getFirmwareVersion(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler)
+            throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             final List<FirmwareVersionDto> firmwareVersions = new Iec61850GetFirmwareVersionCommand()
             .getFirmwareVersionFromDevice(this.iec61850Client, deviceConnection);
@@ -378,12 +442,12 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
     public void setTransition(final SetTransitionDeviceRequest deviceRequest,
-            final DeviceResponseHandler deviceResponseHandler) {
+            final DeviceResponseHandler deviceResponseHandler) throws JMSException {
         try {
             final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
 
@@ -405,22 +469,25 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
                     } catch (final ProtocolAdapterException e) {
                         LOGGER.error("Unable to clear report for device: " + deviceRequest.getDeviceIdentification(), e);
                     }
-                    Iec61850SsldDeviceService.this.iec61850DeviceConnectionService.disconnect(deviceRequest
-                            .getDeviceIdentification());
+                    Iec61850SsldDeviceService.this.iec61850DeviceConnectionService.disconnect(deviceConnection,
+                            deviceRequest);
                 }
             }, this.disconnectDelay);
         } catch (final ConnectionFailureException se) {
             this.handleConnectionFailureException(deviceRequest, deviceResponseHandler, se);
+            this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
+            this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
         }
     }
 
     @Override
     public void updateFirmware(final UpdateFirmwareDeviceRequest deviceRequest,
-            final DeviceResponseHandler deviceResponseHandler) {
+            final DeviceResponseHandler deviceResponseHandler) throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             new Iec61850UpdateFirmwareCommand().pushFirmwareToDevice(this.iec61850Client, deviceConnection,
                     deviceRequest.getFirmwareDomain().concat(deviceRequest.getFirmwareUrl()));
@@ -431,14 +498,15 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
     public void updateDeviceSslCertification(final UpdateDeviceSslCertificationDeviceRequest deviceRequest,
-            final DeviceResponseHandler deviceResponseHandler) {
+            final DeviceResponseHandler deviceResponseHandler) throws JMSException {
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             new Iec61850UpdateSslCertificateCommand().pushSslCertificateToDevice(this.iec61850Client, deviceConnection,
                     deviceRequest.getCertification());
@@ -449,20 +517,19 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     @Override
     public void setEventNotifications(final SetEventNotificationsDeviceRequest deviceRequest,
-            final DeviceResponseHandler deviceResponseHandler) {
-        LOGGER.info("Called setEventNotifications, doing nothing for now and returning OK");
-
+            final DeviceResponseHandler deviceResponseHandler) throws JMSException {
         final List<EventNotificationTypeDto> eventNotifications = deviceRequest.getEventNotificationsContainer()
                 .getEventNotifications();
         final String filter = EventType.getEventTypeFilterMaskForNotificationTypes(eventNotifications);
 
+        DeviceConnection deviceConnection = null;
         try {
-            final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            deviceConnection = this.connectToDevice(deviceRequest);
 
             new Iec61850SetEventNotificationFilterCommand().setEventNotificationFilterOnDevice(this.iec61850Client,
                     deviceConnection, filter);
@@ -473,7 +540,7 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
         }
-        this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+        this.iec61850DeviceConnectionService.disconnect(deviceConnection, deviceRequest);
     }
 
     // ======================================
@@ -481,14 +548,8 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
     // ======================================
 
     private DeviceConnection connectToDevice(final DeviceRequest deviceRequest) throws ConnectionFailureException {
-        this.iec61850DeviceConnectionService.connect(deviceRequest.getIpAddress(),
+        return this.iec61850DeviceConnectionService.connectWithoutConnectionCashing(deviceRequest.getIpAddress(),
                 deviceRequest.getDeviceIdentification(), IED.FLEX_OVL, LogicalDevice.LIGHTING);
-        final ServerModel serverModel = this.iec61850DeviceConnectionService.getServerModel(deviceRequest
-                .getDeviceIdentification());
-        final Iec61850ClientAssociation iec61850ClientAssociation = this.iec61850DeviceConnectionService
-                .getIec61850ClientAssociation(deviceRequest.getDeviceIdentification());
-        return new DeviceConnection(new Iec61850Connection(iec61850ClientAssociation, serverModel),
-                deviceRequest.getDeviceIdentification(), IED.FLEX_OVL);
     }
 
     // ========================
@@ -514,11 +575,12 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
 
     private void handleConnectionFailureException(final DeviceRequest deviceRequest,
             final DeviceResponseHandler deviceResponseHandler,
-            final ConnectionFailureException connectionFailureException) {
-        LOGGER.error("Could not connect to device after all retries", connectionFailureException);
+            final ConnectionFailureException connectionFailureException) throws JMSException {
+        LOGGER.error("Could not connect to device", connectionFailureException);
         final EmptyDeviceResponse deviceResponse = this.createDefaultResponse(deviceRequest,
                 DeviceMessageStatus.FAILURE);
-        deviceResponseHandler.handleException(connectionFailureException, deviceResponse, true);
+        deviceResponseHandler.handleConnectionFailure(new Exception(connectionFailureException.getCause()),
+                deviceResponse);
     }
 
     private void handleProtocolAdapterException(final SetScheduleDeviceRequest deviceRequest,

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850SsldDeviceService.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/Iec61850SsldDeviceService.java
@@ -114,7 +114,6 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
                     deviceRequest.getCorrelationUid(), deviceStatus);
 
             deviceResponseHandler.handleResponse(deviceResponse);
-            this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
         } catch (final ConnectionFailureException se) {
             this.handleConnectionFailureException(deviceRequest, deviceResponseHandler, se);
         } catch (final Exception e) {
@@ -136,15 +135,14 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
                     ssld, RelayType.LIGHT);
 
             final List<PowerUsageDataDto> powerUsageHistoryData = new Iec61850PowerUsageHistoryCommand()
-                    .getPowerUsageHistoryDataFromDevice(this.iec61850Client, deviceConnection,
-                            deviceRequest.getPowerUsageHistoryContainer(), deviceOutputSettingsLightRelays);
+            .getPowerUsageHistoryDataFromDevice(this.iec61850Client, deviceConnection,
+                    deviceRequest.getPowerUsageHistoryContainer(), deviceOutputSettingsLightRelays);
 
             final GetPowerUsageHistoryDeviceResponse deviceResponse = new GetPowerUsageHistoryDeviceResponse(
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
                     deviceRequest.getCorrelationUid(), DeviceMessageStatus.OK, powerUsageHistoryData);
 
             deviceResponseHandler.handleResponse(deviceResponse);
-            this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
         } catch (final ConnectionFailureException se) {
             this.handleConnectionFailureException(deviceRequest, deviceResponseHandler, se);
         } catch (final Exception e) {
@@ -234,7 +232,7 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
 
     private List<LightValueDto> createListOfInternalIndicesToSwitch(
             final List<DeviceOutputSetting> deviceOutputSettings, final List<LightValueDto> lightValues)
-            throws FunctionalException {
+                    throws FunctionalException {
         final List<LightValueDto> relaysWithInternalIdToSwitch = new ArrayList<>();
         LOGGER.info("creating list of internal indices using device output settings and external indices from light values");
         for (final LightValueDto lightValue : lightValues) {
@@ -300,7 +298,6 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
                     deviceRequest.getCorrelationUid(), DeviceMessageStatus.OK, configuration);
 
             deviceResponseHandler.handleResponse(response);
-            this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
         } catch (final ConnectionFailureException se) {
             this.handleConnectionFailureException(deviceRequest, deviceResponseHandler, se);
         } catch (final Exception e) {
@@ -433,7 +430,7 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
             deviceConnection = this.connectToDevice(deviceRequest);
 
             final List<FirmwareVersionDto> firmwareVersions = new Iec61850GetFirmwareVersionCommand()
-            .getFirmwareVersionFromDevice(this.iec61850Client, deviceConnection);
+                    .getFirmwareVersionFromDevice(this.iec61850Client, deviceConnection);
 
             final GetFirmwareVersionDeviceResponse deviceResponse = new GetFirmwareVersionDeviceResponse(
                     deviceRequest.getOrganisationIdentification(), deviceRequest.getDeviceIdentification(),
@@ -451,8 +448,10 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
     @Override
     public void setTransition(final SetTransitionDeviceRequest deviceRequest,
             final DeviceResponseHandler deviceResponseHandler) throws JMSException {
+        DeviceConnection devCon = null;
         try {
             final DeviceConnection deviceConnection = this.connectToDevice(deviceRequest);
+            devCon = deviceConnection;
 
             new Iec61850TransitionCommand().transitionDevice(this.iec61850Client, deviceConnection,
                     deviceRequest.getTransitionTypeContainer());
@@ -478,10 +477,10 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
             }, this.disconnectDelay);
         } catch (final ConnectionFailureException se) {
             this.handleConnectionFailureException(deviceRequest, deviceResponseHandler, se);
-            this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+            this.iec61850DeviceConnectionService.disconnect(devCon, deviceRequest);
         } catch (final Exception e) {
             this.handleException(deviceRequest, deviceResponseHandler, e);
-            this.iec61850DeviceConnectionService.disconnect(deviceRequest.getDeviceIdentification());
+            this.iec61850DeviceConnectionService.disconnect(devCon, deviceRequest);
         }
     }
 
@@ -592,7 +591,7 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
                         + deviceRequest.getDeviceIdentification(), protocolAdapterException);
         final EmptyDeviceResponse deviceResponse = this.createDefaultResponse(deviceRequest,
                 DeviceMessageStatus.FAILURE);
-        deviceResponseHandler.handleException(protocolAdapterException, deviceResponse, true);
+        deviceResponseHandler.handleException(protocolAdapterException, deviceResponse);
     }
 
     private void handleException(final DeviceRequest deviceRequest, final DeviceResponseHandler deviceResponseHandler,
@@ -600,7 +599,7 @@ public class Iec61850SsldDeviceService implements SsldDeviceService {
         LOGGER.error("Unexpected exception", exception);
         final EmptyDeviceResponse deviceResponse = this.createDefaultResponse(deviceRequest,
                 DeviceMessageStatus.FAILURE);
-        deviceResponseHandler.handleException(exception, deviceResponse, false);
+        deviceResponseHandler.handleException(exception, deviceResponse);
     }
 
     // ========================

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850EnableReportingCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850EnableReportingCommand.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.NodeException;
+import com.alliander.osgp.adapter.protocol.iec61850.exceptions.NodeWriteException;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850Client;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.DataAttribute;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.DeviceConnection;
@@ -59,11 +60,11 @@ public class Iec61850EnableReportingCommand {
      * When using the {@link Iec61850ClearReportCommand} the 'sequence number'
      * will always be reset to 0.
      *
-     * @throws NodeException
-     *             In case writing or reading of data-attributes fails.
+     * @throws NodeWriteException
+     *             In case writing of data-attributes fails.
      */
     public void enableReportingOnDeviceWithoutUsingSequenceNumber(final Iec61850Client iec61850Client,
-            final DeviceConnection deviceConnection) throws NodeException {
+            final DeviceConnection deviceConnection) throws NodeWriteException {
         final NodeContainer reporting = deviceConnection.getFcModelNode(LogicalDevice.LIGHTING,
                 LogicalNode.LOGICAL_NODE_ZERO, DataAttribute.REPORTING, Fc.BR);
 

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850GetConfigurationCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850GetConfigurationCommand.java
@@ -49,7 +49,7 @@ public class Iec61850GetConfigurationCommand {
 
     public ConfigurationDto getConfigurationFromDevice(final Iec61850Client iec61850Client,
             final DeviceConnection deviceConnection, final Ssld ssld, final Iec61850Mapper mapper)
-            throws ProtocolAdapterException {
+                    throws ProtocolAdapterException {
         final Function<ConfigurationDto> function = new Function<ConfigurationDto>() {
 
             @Override
@@ -163,7 +163,7 @@ public class Iec61850GetConfigurationCommand {
             }
         };
 
-        return iec61850Client.sendCommandWithRetry(function);
+        return iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 
     private void checkRelayType(final Iec61850Client iec61850Client, final DeviceConnection deviceConnection,

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850GetConfigurationCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850GetConfigurationCommand.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import com.alliander.osgp.adapter.protocol.iec61850.application.mapping.Iec61850Mapper;
 import com.alliander.osgp.adapter.protocol.iec61850.domain.valueobjects.DaylightSavingTimeTransition;
+import com.alliander.osgp.adapter.protocol.iec61850.exceptions.NodeReadException;
 import com.alliander.osgp.adapter.protocol.iec61850.exceptions.ProtocolAdapterException;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.Iec61850Client;
 import com.alliander.osgp.adapter.protocol.iec61850.infra.networking.helper.DataAttribute;
@@ -163,16 +164,25 @@ public class Iec61850GetConfigurationCommand {
                 LOGGER.info("Reading the TLS configuration values");
                 final NodeContainer tls = deviceConnection.getFcModelNode(LogicalDevice.LIGHTING,
                         LogicalNode.STREET_LIGHT_CONFIGURATION, DataAttribute.TLS_CONFIGURATION, Fc.CF);
-                iec61850Client.readNodeDataValues(deviceConnection.getConnection().getClientAssociation(),
-                        tls.getFcmodelNode());
+                if (tls != null) {
+                    try {
+                        iec61850Client.readNodeDataValues(deviceConnection.getConnection().getClientAssociation(),
+                                tls.getFcmodelNode());
 
-                final int tlsPortNumber = (int) tls.getUnsignedInteger(SubDataAttribute.TLS_PORT_NUMBER).getValue();
-                final boolean tlsEnabled = tls.getBoolean(SubDataAttribute.TLS_ENABLED).getValue();
-                final String commonName = tls.getString(SubDataAttribute.TLS_COMMON_NAME);
+                        final int tlsPortNumber = (int) tls.getUnsignedInteger(SubDataAttribute.TLS_PORT_NUMBER)
+                                .getValue();
+                        final boolean tlsEnabled = tls.getBoolean(SubDataAttribute.TLS_ENABLED).getValue();
+                        final String commonName = tls.getString(SubDataAttribute.TLS_COMMON_NAME);
 
-                configuration.setTlsPortNumber(tlsPortNumber);
-                configuration.setTlsEnabled(tlsEnabled);
-                configuration.setCommonNameString(commonName);
+                        configuration.setTlsPortNumber(tlsPortNumber);
+                        configuration.setTlsEnabled(tlsEnabled);
+                        configuration.setCommonNameString(commonName);
+                    } catch (final NodeReadException e) {
+                        LOGGER.info(
+                                "Catched NodeReadException while reading TLS configuration values. Caused by mis-match between server model and IED firmware version. This temporary try-catch maintains backwards compatibility for now. ",
+                                e);
+                    }
+                }
 
                 return configuration;
             }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850GetFirmwareVersionCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850GetFirmwareVersionCommand.java
@@ -65,6 +65,6 @@ public class Iec61850GetFirmwareVersionCommand {
             }
         };
 
-        return iec61850Client.sendCommandWithRetry(function);
+        return iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850GetStatusCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850GetStatusCommand.java
@@ -96,6 +96,6 @@ public class Iec61850GetStatusCommand {
             }
         };
 
-        return iec61850Client.sendCommandWithRetry(function);
+        return iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850PowerUsageHistoryCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850PowerUsageHistoryCommand.java
@@ -66,7 +66,7 @@ public class Iec61850PowerUsageHistoryCommand {
                  * element for the device, where data for the different relays
                  * is combined in the SsldData.relayData some sort of merge
                  * needs to be performed.
-                 *
+                 * 
                  * This can either be a rework of the list currently returned,
                  * or it can be a list constructed based on an altered return
                  * type from getPowerUsageHistoryDataFromRelay (for instance a
@@ -77,7 +77,7 @@ public class Iec61850PowerUsageHistoryCommand {
             }
         };
 
-        return iec61850Client.sendCommandWithRetry(function);
+        return iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 
     private List<PowerUsageDataDto> getPowerUsageHistoryDataFromRelay(final Iec61850Client iec61850Client,

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850RebootCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850RebootCommand.java
@@ -55,6 +55,6 @@ public class Iec61850RebootCommand {
             }
         };
 
-        iec61850Client.sendCommandWithRetry(function);
+        iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850SetConfigurationCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850SetConfigurationCommand.java
@@ -211,6 +211,6 @@ public class Iec61850SetConfigurationCommand {
             }
         };
 
-        iec61850Client.sendCommandWithRetry(function);
+        iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850SetEventNotificationFilterCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850SetEventNotificationFilterCommand.java
@@ -46,6 +46,6 @@ public class Iec61850SetEventNotificationFilterCommand {
             }
         };
 
-        iec61850Client.sendCommandWithRetry(function);
+        iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850SetScheduleCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850SetScheduleCommand.java
@@ -196,7 +196,7 @@ public class Iec61850SetScheduleCommand {
                     }
 
                 };
-                iec61850Client.sendCommandWithRetry(function);
+                iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
             }
         } catch (final FunctionalException e) {
             throw new ProtocolAdapterException(e.getMessage(), e);
@@ -208,7 +208,7 @@ public class Iec61850SetScheduleCommand {
      */
     private Map<Integer, List<ScheduleEntry>> createScheduleEntries(final List<ScheduleDto> scheduleList,
             final Ssld ssld, final RelayTypeDto relayTypeDto, final SsldDataService ssldDataService)
-                    throws FunctionalException {
+            throws FunctionalException {
 
         final Map<Integer, List<ScheduleEntry>> relaySchedulesEntries = new HashMap<>();
 
@@ -259,7 +259,7 @@ public class Iec61850SetScheduleCommand {
                         // type.
                         this.checkRelayForSchedules(
                                 ssldDataService.getDeviceOutputSettingForInternalIndex(ssld, internalIndex)
-                                        .getRelayType(), relayType, internalIndex);
+                                .getRelayType(), relayType, internalIndex);
 
                         // Adding it to scheduleEntries.
                         final List<ScheduleEntry> scheduleEntries = new ArrayList<>();

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850TransitionCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850TransitionCommand.java
@@ -66,6 +66,6 @@ public class Iec61850TransitionCommand {
             }
         };
 
-        iec61850Client.sendCommandWithRetry(function);
+        iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850UpdateFirmwareCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850UpdateFirmwareCommand.java
@@ -60,6 +60,6 @@ public class Iec61850UpdateFirmwareCommand {
             }
         };
 
-        iec61850Client.sendCommandWithRetry(function);
+        iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 }

--- a/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850UpdateSslCertificateCommand.java
+++ b/osgp-protocol-adapter-iec61850/src/main/java/com/alliander/osgp/adapter/protocol/iec61850/infra/networking/services/commands/Iec61850UpdateSslCertificateCommand.java
@@ -31,7 +31,7 @@ public class Iec61850UpdateSslCertificateCommand {
 
     public void pushSslCertificateToDevice(final Iec61850Client iec61850Client,
             final DeviceConnection deviceConnection, final CertificationDto certification)
-                    throws ProtocolAdapterException {
+            throws ProtocolAdapterException {
         final Function<Void> function = new Function<Void>() {
 
             @Override
@@ -76,6 +76,6 @@ public class Iec61850UpdateSslCertificateCommand {
             }
         };
 
-        iec61850Client.sendCommandWithRetry(function);
+        iec61850Client.sendCommandWithRetry(function, deviceConnection.getDeviceIdentification());
     }
 }


### PR DESCRIPTION
- removes usage of connection-cache for SSLD connections
- adds logging of duration per function, see FLEX-2355
- implements SessionAwareMessageListener in order to execute reties/redeliveries when JMSExceptions are thrown
- uses JMSXDeliveryCount to determine if the last redelivery has been executed in order to sent a ProtocolResponseMessage
- replaces deprecated code when constructing ProtocolResponseMesssages
- logs number of retries when NodeReadException/NodeWriteException occurs
- improves error handling for switchLightRelay() used by setLight() and runSelfTest()
